### PR TITLE
Add voice command layer and Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,26 @@ PGSQL_PORT=5432
 PGSQL_DATABASE=joma_khoroch
 ```
 
-### 3. Install & Run
+### 3. Google Sign-In (optional)
+
+The dummy email/password login always works. To additionally enable **Sign in with Google**:
+
+1. In [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials), create an **OAuth 2.0 Client ID** (type: Web application).
+2. Add **Authorized redirect URIs**:
+   - `http://localhost:3000/api/auth/callback/google` (dev)
+   - `https://your-domain/api/auth/callback/google` (prod)
+3. Put the client ID/secret in `.env.local`:
+   ```env
+   GOOGLE_CLIENT_ID=your_client_id
+   GOOGLE_CLIENT_SECRET=your_client_secret
+   # Restrict who can sign in with Google (comma-separated). Strongly
+   # recommended for a finance app — leave empty to allow any Google account.
+   ALLOWED_GOOGLE_EMAILS=you@gmail.com
+   ```
+
+The Google button appears on the sign-in page only when these are configured. Set the same variables in your **Vercel project env** for production.
+
+### 4. Install & Run
 
 ```bash
 npm install

--- a/components/voiceCapture.js
+++ b/components/voiceCapture.js
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
 import {
   Box,
   Card,
@@ -12,33 +13,68 @@ import {
   Button,
   Chip,
   LinearProgress,
+  Alert,
 } from "@mui/material";
 import MicIcon from "@mui/icons-material/Mic";
 import StopIcon from "@mui/icons-material/Stop";
 import axios from "axios";
 import {
-  parseTranscript,
+  parseCommand,
+  resolveTarget,
+  runQuery,
   CATEGORIES,
   CATEGORY_LABELS,
   PAYMENT_METHODS,
 } from "@jk/shared";
 
+const EXAMPLES = [
+  "spent 600 on lunch with Rafi",
+  "delete my last lunch",
+  "change that 600 to 700",
+  "how much did I spend on food this week",
+  "set daily limit to 1000",
+  "show insights",
+];
+
+const taka = (n) => `৳${Number(n || 0).toLocaleString("en-IN", { maximumFractionDigits: 2 })}`;
+
+/** Map a raw `expenses` row to the shared ExpenseRecord shape. */
+const toRecord = (r) => ({
+  id: r.expense_id,
+  title: r.expense_title ?? "",
+  amount: Math.abs(Number(r.expense)),
+  type: r.expense_type,
+  category: r.category ?? null,
+  details: r.expense_details ?? "",
+  createdAt: new Date(r.created_date).toISOString(),
+});
+
+function speak(text) {
+  try {
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(new SpeechSynthesisUtterance(text));
+    }
+  } catch {}
+}
+
 /**
- * Voice-first capture. Speak a transaction → parse to a structured draft →
- * confirm/edit → save through the existing /api/insertexpense pipeline.
- *
- * Parsing runs client-side (instant, offline). Speech recognition uses the
- * browser Web Speech API where available, and falls back to a text field on
- * browsers that lack it (notably iOS Safari) so the flow always works.
+ * Voice command interface. A transcript is classified by parseCommand() into an
+ * intent, then routed: create shows an editable draft; delete/edit ask for
+ * confirmation against the resolved transaction; queries answer inline (and
+ * aloud); set-limit confirms; navigate routes.
  */
-export default function VoiceCapture({ getExpenselist }) {
+export default function VoiceCapture({ getExpenselist, expenses = [], balance = 0 }) {
+  const router = useRouter();
   const recognitionRef = useRef(null);
   const [supported, setSupported] = useState(false);
   const [listening, setListening] = useState(false);
-  const [lang, setLang] = useState("en-US"); // en-US | bn-BD
+  const [lang, setLang] = useState("en-US");
   const [transcript, setTranscript] = useState("");
-  const [draft, setDraft] = useState(null);
-  const [saving, setSaving] = useState(false);
+  const [command, setCommand] = useState(null);
+  const [draft, setDraft] = useState(null); // editable copy for "create"
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState(null); // { type, text }
   const [error, setError] = useState("");
 
   useEffect(() => {
@@ -48,8 +84,50 @@ export default function VoiceCapture({ getExpenselist }) {
     setSupported(Boolean(SR));
   }, []);
 
+  const records = useMemo(() => (expenses || []).map(toRecord), [expenses]);
+
+  // Best-match transaction for delete/update commands.
+  const target = useMemo(() => {
+    if (!command || (command.kind !== "delete" && command.kind !== "update")) return null;
+    return resolveTarget(command.target, records)[0] ?? null;
+  }, [command, records]);
+
+  const reset = () => {
+    setCommand(null);
+    setDraft(null);
+    setTranscript("");
+  };
+
+  const handleTranscript = (text) => {
+    if (!text) return;
+    const cmd = parseCommand(text);
+    setError("");
+    setMessage(null);
+
+    // Intents that need no confirmation execute immediately.
+    if (cmd.kind === "navigate") {
+      setMessage({ type: "info", text: `Opening ${cmd.to}…` });
+      router.push(cmd.to === "insights" ? "/insights" : "/");
+      return;
+    }
+    if (cmd.kind === "query") {
+      const answer =
+        cmd.query.metric === "balance"
+          ? `Your balance is ${taka(balance)}.`
+          : runQuery(cmd.query, records).text;
+      setMessage({ type: "success", text: answer });
+      speak(answer);
+      return;
+    }
+
+    setCommand(cmd);
+    setDraft(cmd.kind === "create" ? cmd.draft : null);
+  };
+
+  // --- speech recognition ---
   const startListening = () => {
     setError("");
+    setMessage(null);
     const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
     if (!SR) return;
     const rec = new SR();
@@ -77,12 +155,13 @@ export default function VoiceCapture({ getExpenselist }) {
       const text = finalText.trim();
       if (text) {
         setTranscript(text);
-        setDraft(parseTranscript(text));
+        handleTranscript(text);
       }
     };
 
     recognitionRef.current = rec;
     setTranscript("");
+    setCommand(null);
     setDraft(null);
     setListening(true);
     rec.start();
@@ -93,66 +172,114 @@ export default function VoiceCapture({ getExpenselist }) {
     setListening(false);
   };
 
-  const parseTyped = () => {
-    const text = transcript.trim();
-    if (text) setDraft(parseTranscript(text));
-  };
+  const parseTyped = () => handleTranscript(transcript.trim());
 
+  // --- executors ---
   const updateDraft = (patch) => setDraft((d) => ({ ...d, ...patch }));
 
-  const save = async () => {
-    if (!draft || !draft.amount) return;
-    setSaving(true);
-    setError("");
+  const saveCreate = async () => {
+    if (!draft?.amount) return;
+    setBusy(true);
     try {
       const isIncome = draft.direction === "income";
       const label = CATEGORY_LABELS[draft.category] ?? "Other";
-      const payload = {
+      await axios.post("/api/insertexpense", {
         title: draft.counterparty ? `${label} · ${draft.counterparty}` : label,
-        // Match the manual form: expenses are stored as a negative number.
         expense: isIncome ? draft.amount : -draft.amount,
         type: isIncome ? "add" : "remove",
         details: (draft.note || draft.rawTranscript || "Voice entry").trim(),
         category: draft.category,
-      };
-      await axios.post("/api/insertexpense", payload);
-      setDraft(null);
-      setTranscript("");
+      });
+      setMessage({ type: "success", text: `Saved ${taka(draft.amount)} · ${label}` });
+      reset();
       await getExpenselist?.(false);
-    } catch (e) {
+    } catch {
       setError("Couldn't save. Please try again.");
     } finally {
-      setSaving(false);
+      setBusy(false);
     }
   };
 
-  const confidencePct = useMemo(
-    () => (draft ? Math.round(draft.confidence * 100) : 0),
-    [draft]
-  );
-  const lowConfidence = draft && draft.confidence < 0.6;
+  const confirmDelete = async () => {
+    if (!target) return;
+    setBusy(true);
+    try {
+      await axios.post("/api/deleteexpense", { id: target.id });
+      setMessage({ type: "success", text: `Deleted ${taka(target.amount)} · ${target.title}` });
+      reset();
+      await getExpenselist?.(false);
+    } catch {
+      setError("Couldn't delete. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmUpdate = async () => {
+    if (!target || !command || command.kind !== "update") return;
+    const { changes } = command;
+    setBusy(true);
+    try {
+      const newAmount = changes.amount ?? target.amount;
+      const newType = changes.direction
+        ? changes.direction === "income"
+          ? "add"
+          : "remove"
+        : target.type;
+      const newCategory = changes.category ?? target.category;
+      await axios.post("/api/updateexpense", {
+        id: target.id,
+        expense: newType === "remove" ? -newAmount : newAmount,
+        type: newType,
+        category: newCategory,
+      });
+      setMessage({ type: "success", text: "Transaction updated." });
+      reset();
+      await getExpenselist?.(false);
+    } catch {
+      setError("Couldn't update. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmSetLimit = async () => {
+    if (!command || command.kind !== "set_limit") return;
+    setBusy(true);
+    try {
+      if (command.which === "daily") {
+        await axios.post("/api/updateDailyLimit", { dailyLimit: command.amount });
+      } else {
+        await axios.post("/api/updateMonthlyExpenseTarget", {
+          monthlyExpenseTarget: command.amount,
+        });
+      }
+      setMessage({
+        type: "success",
+        text: `${command.which === "daily" ? "Daily limit" : "Monthly target"} set to ${taka(command.amount)}.`,
+      });
+      reset();
+    } catch {
+      setError("Couldn't update the limit. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
 
   return (
     <Card sx={{ borderRadius: 4, p: 3, mb: 3, border: "1px solid #e2e8f0" }}>
-      <Stack
-        direction="row"
-        justifyContent="space-between"
-        alignItems="center"
-        sx={{ mb: 2 }}
-      >
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
         <Typography variant="h6" sx={{ fontWeight: 700 }}>
-          🎤 Speak a transaction
+          🎤 Voice command
         </Typography>
-        <ToggleButtonGroup
-          value={lang}
-          exclusive
-          size="small"
-          onChange={(_, v) => v && setLang(v)}
-        >
+        <ToggleButtonGroup value={lang} exclusive size="small" onChange={(_, v) => v && setLang(v)}>
           <ToggleButton value="en-US">EN</ToggleButton>
           <ToggleButton value="bn-BD">বাংলা</ToggleButton>
         </ToggleButtonGroup>
       </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Add, delete, edit, ask “how much…”, set limits, or navigate — by voice.
+      </Typography>
 
       {/* Capture surface */}
       {supported ? (
@@ -171,161 +298,275 @@ export default function VoiceCapture({ getExpenselist }) {
               transition: "all 0.2s",
             }}
           >
-            {listening ? (
-              <StopIcon sx={{ fontSize: 40 }} />
-            ) : (
-              <MicIcon sx={{ fontSize: 40 }} />
-            )}
+            {listening ? <StopIcon sx={{ fontSize: 40 }} /> : <MicIcon sx={{ fontSize: 40 }} />}
           </IconButton>
           <Typography variant="body2" color="text.secondary">
-            {listening ? "Listening… tap to stop" : "Tap and say what you spent"}
+            {listening ? "Listening… tap to stop" : "Tap and speak a command"}
           </Typography>
           {transcript ? (
-            <Typography sx={{ fontStyle: "italic", textAlign: "center" }}>
-              “{transcript}”
-            </Typography>
+            <Typography sx={{ fontStyle: "italic", textAlign: "center" }}>“{transcript}”</Typography>
           ) : null}
         </Stack>
       ) : (
         <Stack spacing={1}>
           <Typography variant="body2" color="text.secondary">
-            Voice input isn’t supported in this browser — type what you’d say:
+            Voice input isn’t supported in this browser — type a command:
           </Typography>
           <TextField
             fullWidth
             size="small"
-            placeholder="e.g. just spent 600 on lunch with Rafi"
+            placeholder="e.g. delete my last lunch"
             value={transcript}
             onChange={(e) => setTranscript(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && parseTyped()}
           />
           <Button onClick={parseTyped} variant="outlined" sx={{ alignSelf: "flex-start" }}>
-            Parse
+            Run
           </Button>
         </Stack>
       )}
 
+      {/* Example commands */}
+      <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mt: 2 }}>
+        {EXAMPLES.map((ex) => (
+          <Chip
+            key={ex}
+            label={ex}
+            size="small"
+            variant="outlined"
+            onClick={() => {
+              setTranscript(ex);
+              handleTranscript(ex);
+            }}
+          />
+        ))}
+      </Stack>
+
       {error ? (
-        <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+        <Alert severity="error" sx={{ mt: 2 }} onClose={() => setError("")}>
           {error}
-        </Typography>
+        </Alert>
+      ) : null}
+      {message ? (
+        <Alert severity={message.type} sx={{ mt: 2 }} onClose={() => setMessage(null)}>
+          {message.text}
+        </Alert>
       ) : null}
 
-      {/* Editable draft */}
-      {draft ? (
+      {/* --- Intent-specific UI --- */}
+      {command?.kind === "create" && draft ? (
+        <CreateDraft
+          draft={draft}
+          busy={busy}
+          onChange={updateDraft}
+          onSave={saveCreate}
+          onCancel={reset}
+        />
+      ) : null}
+
+      {command?.kind === "delete" ? (
+        <ConfirmPanel
+          title="Delete this transaction?"
+          danger
+          record={target}
+          busy={busy}
+          onConfirm={confirmDelete}
+          onCancel={reset}
+          confirmLabel="Delete"
+        />
+      ) : null}
+
+      {command?.kind === "update" ? (
+        <ConfirmPanel
+          title="Apply this change?"
+          record={target}
+          changes={command.changes}
+          busy={busy}
+          onConfirm={confirmUpdate}
+          onCancel={reset}
+          confirmLabel="Update"
+        />
+      ) : null}
+
+      {command?.kind === "set_limit" ? (
         <Box sx={{ mt: 3, pt: 3, borderTop: "1px dashed #e2e8f0" }}>
-          <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            sx={{ mb: 2 }}
-          >
-            <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-              Review & save
-            </Typography>
-            <Chip
-              size="small"
-              label={`${lowConfidence ? "Check this" : "Looks good"} · ${confidencePct}%`}
-              color={lowConfidence ? "warning" : "success"}
-              variant={lowConfidence ? "filled" : "outlined"}
-            />
-          </Stack>
-
-          <Stack spacing={2}>
-            <TextField
-              label="Amount (BDT)"
-              type="number"
-              size="small"
-              fullWidth
-              value={draft.amount ?? ""}
-              onChange={(e) =>
-                updateDraft({
-                  amount: e.target.value ? Number(e.target.value) : null,
-                })
-              }
-            />
-
-            <ToggleButtonGroup
-              value={draft.direction}
-              exclusive
-              size="small"
-              fullWidth
-              onChange={(_, v) => v && updateDraft({ direction: v })}
-            >
-              <ToggleButton value="expense">Expense</ToggleButton>
-              <ToggleButton value="income">Income</ToggleButton>
-            </ToggleButtonGroup>
-
-            <Stack direction="row" spacing={2}>
-              <TextField
-                select
-                label="Category"
-                size="small"
-                fullWidth
-                value={draft.category}
-                onChange={(e) => updateDraft({ category: e.target.value })}
-              >
-                {CATEGORIES.map((c) => (
-                  <MenuItem key={c} value={c}>
-                    {CATEGORY_LABELS[c]}
-                  </MenuItem>
-                ))}
-              </TextField>
-              <TextField
-                select
-                label="Method"
-                size="small"
-                fullWidth
-                value={draft.paymentMethod ?? ""}
-                onChange={(e) =>
-                  updateDraft({ paymentMethod: e.target.value || null })
-                }
-              >
-                <MenuItem value="">—</MenuItem>
-                {PAYMENT_METHODS.map((p) => (
-                  <MenuItem key={p} value={p}>
-                    {p.charAt(0).toUpperCase() + p.slice(1)}
-                  </MenuItem>
-                ))}
-              </TextField>
-            </Stack>
-
-            <TextField
-              label="Who / where"
-              size="small"
-              fullWidth
-              value={draft.counterparty ?? ""}
-              onChange={(e) =>
-                updateDraft({ counterparty: e.target.value || null })
-              }
-            />
-            <TextField
-              label="Note"
-              size="small"
-              fullWidth
-              multiline
-              value={draft.note}
-              onChange={(e) => updateDraft({ note: e.target.value })}
-            />
-
-            {saving ? <LinearProgress /> : null}
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
-              <Button onClick={() => setDraft(null)} disabled={saving}>
-                Discard
-              </Button>
-              <Button
-                onClick={save}
-                variant="contained"
-                disableElevation
-                disabled={saving || !draft.amount}
-                sx={{ px: 4, fontWeight: 800, borderRadius: 2 }}
-              >
-                Save Transaction
-              </Button>
-            </Stack>
+          <Typography sx={{ mb: 2 }}>
+            Set your <b>{command.which === "daily" ? "daily limit" : "monthly target"}</b> to{" "}
+            <b>{taka(command.amount)}</b>?
+          </Typography>
+          {busy ? <LinearProgress sx={{ mb: 2 }} /> : null}
+          <Stack direction="row" spacing={1} justifyContent="flex-end">
+            <Button onClick={reset} disabled={busy}>
+              Cancel
+            </Button>
+            <Button variant="contained" disableElevation onClick={confirmSetLimit} disabled={busy}>
+              Set
+            </Button>
           </Stack>
         </Box>
       ) : null}
+
+      {command?.kind === "unknown" ? (
+        <Alert severity="warning" sx={{ mt: 2 }} onClose={reset}>
+          Didn’t catch that. Try one of the examples above.
+        </Alert>
+      ) : null}
     </Card>
+  );
+}
+
+/** Confirmation panel for delete/update, showing the resolved transaction. */
+function ConfirmPanel({ title, record, changes, danger, busy, onConfirm, onCancel, confirmLabel }) {
+  if (!record) {
+    return (
+      <Alert severity="warning" sx={{ mt: 2 }} onClose={onCancel}>
+        Couldn’t find a matching transaction. Try naming the amount or category.
+      </Alert>
+    );
+  }
+  return (
+    <Box sx={{ mt: 3, pt: 3, borderTop: "1px dashed #e2e8f0" }}>
+      <Typography sx={{ fontWeight: 700, mb: 1.5 }}>{title}</Typography>
+      <Card variant="outlined" sx={{ p: 2, borderRadius: 3, mb: 2 }}>
+        <Stack direction="row" justifyContent="space-between">
+          <Box>
+            <Typography sx={{ fontWeight: 600 }}>{record.title}</Typography>
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {record.details}
+            </Typography>
+          </Box>
+          <Typography sx={{ fontWeight: 700, color: record.type === "add" ? "success.main" : "error.main" }}>
+            {record.type === "add" ? "+" : "−"}
+            {taka(record.amount)}
+          </Typography>
+        </Stack>
+        {changes && (changes.amount !== undefined || changes.category !== undefined) ? (
+          <Box sx={{ mt: 1.5, pt: 1.5, borderTop: "1px solid #eef2f7" }}>
+            <Typography variant="body2" color="primary" sx={{ fontWeight: 600 }}>
+              → {changes.amount !== undefined ? `Amount: ${taka(changes.amount)}` : ""}
+              {changes.amount !== undefined && changes.category !== undefined ? " · " : ""}
+              {changes.category !== undefined ? `Category: ${CATEGORY_LABELS[changes.category]}` : ""}
+            </Typography>
+          </Box>
+        ) : null}
+      </Card>
+      {busy ? <LinearProgress sx={{ mb: 2 }} /> : null}
+      <Stack direction="row" spacing={1} justifyContent="flex-end">
+        <Button onClick={onCancel} disabled={busy}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color={danger ? "error" : "primary"}
+          disableElevation
+          onClick={onConfirm}
+          disabled={busy}
+          sx={{ px: 3, fontWeight: 800, borderRadius: 2 }}
+        >
+          {confirmLabel}
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+
+/** Editable draft for the create intent. */
+function CreateDraft({ draft, busy, onChange, onSave, onCancel }) {
+  const low = draft.confidence < 0.6;
+  return (
+    <Box sx={{ mt: 3, pt: 3, borderTop: "1px dashed #e2e8f0" }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+          Review & save
+        </Typography>
+        <Chip
+          size="small"
+          label={`${low ? "Check this" : "Looks good"} · ${Math.round(draft.confidence * 100)}%`}
+          color={low ? "warning" : "success"}
+          variant={low ? "filled" : "outlined"}
+        />
+      </Stack>
+      <Stack spacing={2}>
+        <TextField
+          label="Amount (BDT)"
+          type="number"
+          size="small"
+          fullWidth
+          value={draft.amount ?? ""}
+          onChange={(e) => onChange({ amount: e.target.value ? Number(e.target.value) : null })}
+        />
+        <ToggleButtonGroup
+          value={draft.direction}
+          exclusive
+          size="small"
+          fullWidth
+          onChange={(_, v) => v && onChange({ direction: v })}
+        >
+          <ToggleButton value="expense">Expense</ToggleButton>
+          <ToggleButton value="income">Income</ToggleButton>
+        </ToggleButtonGroup>
+        <Stack direction="row" spacing={2}>
+          <TextField
+            select
+            label="Category"
+            size="small"
+            fullWidth
+            value={draft.category}
+            onChange={(e) => onChange({ category: e.target.value })}
+          >
+            {CATEGORIES.map((c) => (
+              <MenuItem key={c} value={c}>
+                {CATEGORY_LABELS[c]}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            select
+            label="Method"
+            size="small"
+            fullWidth
+            value={draft.paymentMethod ?? ""}
+            onChange={(e) => onChange({ paymentMethod: e.target.value || null })}
+          >
+            <MenuItem value="">—</MenuItem>
+            {PAYMENT_METHODS.map((p) => (
+              <MenuItem key={p} value={p}>
+                {p.charAt(0).toUpperCase() + p.slice(1)}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Stack>
+        <TextField
+          label="Who / where"
+          size="small"
+          fullWidth
+          value={draft.counterparty ?? ""}
+          onChange={(e) => onChange({ counterparty: e.target.value || null })}
+        />
+        <TextField
+          label="Note"
+          size="small"
+          fullWidth
+          multiline
+          value={draft.note}
+          onChange={(e) => onChange({ note: e.target.value })}
+        />
+        {busy ? <LinearProgress /> : null}
+        <Stack direction="row" spacing={1} justifyContent="flex-end">
+          <Button onClick={onCancel} disabled={busy}>
+            Discard
+          </Button>
+          <Button
+            onClick={onSave}
+            variant="contained"
+            disableElevation
+            disabled={busy || !draft.amount}
+            sx={{ px: 4, fontWeight: 800, borderRadius: 2 }}
+          >
+            Save Transaction
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
   );
 }

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
+import GoogleProvider from "next-auth/providers/google";
 
 export const authOptions = {
   // Support both casing variations for the secret
@@ -60,9 +61,35 @@ export const authOptions = {
         }
       },
     }),
-    // ...add more providers here
+    // Google OAuth — only registered when credentials are configured, so the
+    // app still runs (with just the dummy login) when they're absent.
+    ...(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
+      ? [
+          GoogleProvider({
+            clientId: process.env.GOOGLE_CLIENT_ID,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+          }),
+        ]
+      : []),
   ],
   callbacks: {
+    // Authorization gate. The Credentials provider already verifies in
+    // authorize(), so it's always allowed here. For Google we require a
+    // verified email and, if an allowlist is set, restrict to those addresses —
+    // critical for a personal finance app so not just any Google user gets in.
+    async signIn({ account, profile, user }) {
+      if (account?.provider === "google") {
+        if (profile && profile.email_verified === false) return false;
+        const allow = (process.env.ALLOWED_GOOGLE_EMAILS || "")
+          .split(",")
+          .map((s) => s.trim().toLowerCase())
+          .filter(Boolean);
+        if (allow.length === 0) return true; // no allowlist configured → open
+        const email = (profile?.email || user?.email || "").toLowerCase();
+        return allow.includes(email);
+      }
+      return true;
+    },
     async jwt({ token, user }) {
       return { ...token, ...user };
     },

--- a/pages/api/updateexpense/index.js
+++ b/pages/api/updateexpense/index.js
@@ -1,0 +1,43 @@
+import conn from "../../../lib/db";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+// Edit an existing transaction. Only the fields provided are changed
+// (COALESCE keeps the current value for anything sent as null/undefined).
+export default async (req, res) => {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    res.status(401).end();
+    return;
+  }
+  try {
+    const { id, title, expense, type, details, category } = req.body;
+    if (!id) {
+      res.status(400).json({ error: "id is required" });
+      return;
+    }
+    const query = `
+      UPDATE expenses SET
+        expense_title  = COALESCE($2, expense_title),
+        expense_details = COALESCE($3, expense_details),
+        expense        = COALESCE($4, expense),
+        expense_type   = COALESCE($5, expense_type),
+        category       = COALESCE($6, category),
+        updated_date   = $7
+      WHERE expense_id = $1`;
+    const values = [
+      id,
+      title ?? null,
+      details ?? null,
+      expense ?? null,
+      type ?? null,
+      category ?? null,
+      new Date(),
+    ];
+    const result = await conn.query(query, values);
+    res.status(200).json(result);
+  } catch (error) {
+    console.error("Database error in updateexpense:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+};

--- a/pages/auth/signin.js
+++ b/pages/auth/signin.js
@@ -11,7 +11,17 @@ import {
 } from "@mui/material";
 import { Stack } from "@mui/system";
 
-import { TextField, Container, Paper } from "@mui/material";
+import { TextField, Container, Paper, Divider } from "@mui/material";
+
+// Inline Google "G" mark so we don't pull in an extra icon dependency.
+const GoogleMark = () => (
+  <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
+    <path fill="#FFC107" d="M43.6 20.5H42V20H24v8h11.3C33.7 32.9 29.3 36 24 36c-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.9 1.2 8 3.1l5.7-5.7C34.5 6.5 29.5 4.5 24 4.5 13.2 4.5 4.5 13.2 4.5 24S13.2 43.5 24 43.5 43.5 34.8 43.5 24c0-1.2-.1-2.3-.4-3.5z" />
+    <path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.7 16 19 13 24 13c3.1 0 5.9 1.2 8 3.1l5.7-5.7C34.5 6.5 29.5 4.5 24 4.5 16.3 4.5 9.7 8.9 6.3 14.7z" />
+    <path fill="#4CAF50" d="M24 43.5c5.2 0 10-2 13.6-5.2l-6.3-5.3C29.2 34.5 26.7 35.5 24 35.5c-5.3 0-9.7-3.1-11.3-7.5l-6.5 5C9.6 39 16.2 43.5 24 43.5z" />
+    <path fill="#1976D2" d="M43.6 20.5H42V20H24v8h11.3c-.8 2.3-2.3 4.2-4.1 5.5l6.3 5.3C41.2 36.2 43.5 30.6 43.5 24c0-1.2-.1-2.3-.4-3.5z" />
+  </svg>
+);
 
 const Signin = ({ providers }) => {
   const email = useRef("");
@@ -98,6 +108,32 @@ const Signin = ({ providers }) => {
               </Button>
             </Stack>
           </form>
+
+          {providers?.google ? (
+            <>
+              <Divider sx={{ my: 3, color: "text.secondary", fontSize: 13 }}>
+                or
+              </Divider>
+              <Button
+                variant="outlined"
+                fullWidth
+                size="large"
+                startIcon={<GoogleMark />}
+                onClick={() => signIn("google", { callbackUrl: "/" })}
+                sx={{
+                  py: 1.5,
+                  borderRadius: 2,
+                  fontWeight: 700,
+                  color: "text.primary",
+                  borderColor: "#e2e8f0",
+                  textTransform: "none",
+                  "&:hover": { borderColor: "#cbd5e1", bgcolor: "#f8fafc" },
+                }}
+              >
+                Continue with Google
+              </Button>
+            </>
+          ) : null}
 
           <Box sx={{ mt: 4, textAlign: "center" }}>
             <Typography variant="body2" color="text.secondary">

--- a/pages/index.js
+++ b/pages/index.js
@@ -272,7 +272,11 @@ export default function Home() {
             </Box>
           ) : (
             <>
-              <VoiceCapture getExpenselist={getExpenselist} />
+              <VoiceCapture
+                getExpenselist={getExpenselist}
+                expenses={expenseList}
+                balance={balance}
+              />
               <ExpenseEditCard getExpenselist={getExpenselist} />
             </>
           )}

--- a/voice/packages/shared/dist/command/index.d.ts
+++ b/voice/packages/shared/dist/command/index.d.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export { parseCommand } from "./parse";
+export { resolveTarget, runQuery } from "./resolve";
+export type { QueryResult } from "./resolve";

--- a/voice/packages/shared/dist/command/index.js
+++ b/voice/packages/shared/dist/command/index.js
@@ -14,6 +14,10 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.runQuery = exports.resolveTarget = exports.parseCommand = void 0;
 __exportStar(require("./types"), exports);
-__exportStar(require("./parser"), exports);
-__exportStar(require("./command"), exports);
+var parse_1 = require("./parse");
+Object.defineProperty(exports, "parseCommand", { enumerable: true, get: function () { return parse_1.parseCommand; } });
+var resolve_1 = require("./resolve");
+Object.defineProperty(exports, "resolveTarget", { enumerable: true, get: function () { return resolve_1.resolveTarget; } });
+Object.defineProperty(exports, "runQuery", { enumerable: true, get: function () { return resolve_1.runQuery; } });

--- a/voice/packages/shared/dist/command/parse.d.ts
+++ b/voice/packages/shared/dist/command/parse.d.ts
@@ -1,0 +1,23 @@
+/**
+ * parseCommand: transcript → Command (intent + entities).
+ *
+ * Detection runs in a fixed precedence so overlapping keywords resolve
+ * predictably:
+ *   1. delete   — "delete/remove ..."
+ *   2. set_limit — mentions a limit/target + an amount ("set daily limit to 1000")
+ *   3. navigate — names a destination ("show insights", "go home")
+ *   4. update   — "change/edit/recategorize ..."
+ *   5. query    — "how much ...", "what's my balance"
+ *   6. create   — falls through here if there's an amount (the capture path)
+ *   7. unknown  — nothing recognized
+ *
+ * Supported edit/delete phrasings (deterministic, not free-form):
+ *   delete:  "delete my last lunch", "remove the 600 taka one", "delete the last one"
+ *   update:  "change that 600 to 700", "make the last one 450",
+ *            "recategorize my last lunch as groceries"
+ *   query:   "how much did I spend on food this week", "what's my balance"
+ *   limit:   "set my daily limit to 1000", "monthly target 30000"
+ *   nav:     "show insights", "go to dashboard"
+ */
+import type { Command } from "./types";
+export declare function parseCommand(transcript: string): Command;

--- a/voice/packages/shared/dist/command/parse.js
+++ b/voice/packages/shared/dist/command/parse.js
@@ -1,0 +1,140 @@
+"use strict";
+/**
+ * parseCommand: transcript → Command (intent + entities).
+ *
+ * Detection runs in a fixed precedence so overlapping keywords resolve
+ * predictably:
+ *   1. delete   — "delete/remove ..."
+ *   2. set_limit — mentions a limit/target + an amount ("set daily limit to 1000")
+ *   3. navigate — names a destination ("show insights", "go home")
+ *   4. update   — "change/edit/recategorize ..."
+ *   5. query    — "how much ...", "what's my balance"
+ *   6. create   — falls through here if there's an amount (the capture path)
+ *   7. unknown  — nothing recognized
+ *
+ * Supported edit/delete phrasings (deterministic, not free-form):
+ *   delete:  "delete my last lunch", "remove the 600 taka one", "delete the last one"
+ *   update:  "change that 600 to 700", "make the last one 450",
+ *            "recategorize my last lunch as groceries"
+ *   query:   "how much did I spend on food this week", "what's my balance"
+ *   limit:   "set my daily limit to 1000", "monthly target 30000"
+ *   nav:     "show insights", "go to dashboard"
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseCommand = parseCommand;
+const normalize_1 = require("../parser/normalize");
+const amount_1 = require("../parser/amount");
+const category_1 = require("../parser/category");
+const counterparty_1 = require("../parser/counterparty");
+const parser_1 = require("../parser");
+const DELETE_RE = /\b(delete|remove|cancel|muche|baad|mucho)\b/;
+const EDIT_RE = /\b(change|update|edit|recategorize|rename|make)\b/;
+const LIMIT_RE = /\b(limit|target)\b/;
+const BALANCE_RE = /\b(balance|baki)\b/;
+const TOTAL_RE = /\b(how much|how many|koto|total|ktotal)\b/;
+const NAV_INSIGHTS_RE = /\b(insight|insights|report|reports|analytics|chart|charts)\b/;
+const NAV_HOME_RE = /\b(home|dashboard|main)\b/;
+function detectPeriod(text) {
+    if (/\b(today|aj|ajke)\b/.test(text))
+        return "today";
+    if (/\b(this week|week|saptah|saptaho)\b/.test(text))
+        return "week";
+    if (/\b(this month|month|mas|mash)\b/.test(text))
+        return "month";
+    return "month"; // most useful default for a spending question
+}
+/** Pull a category out of a fragment, or null if none is confident. */
+function categoryOf(text) {
+    const r = (0, category_1.extractCategory)(text);
+    return r.category !== "other" && r.confidence > 0 ? r.category : null;
+}
+function parseTarget(text) {
+    const norm = (0, normalize_1.normalize)(text);
+    const ordinal = /\b(last|recent|latest|sesh|previous)\b/.test(norm)
+        ? "last"
+        : /\b(first|oldest|earliest)\b/.test(norm)
+            ? "first"
+            : null;
+    return {
+        ordinal,
+        category: categoryOf(norm),
+        counterparty: (0, counterparty_1.extractCounterparty)(text).counterparty,
+        amount: (0, amount_1.extractAmount)(norm).amount,
+    };
+}
+function parseUpdate(text) {
+    const norm = (0, normalize_1.normalize)(text);
+    const changes = {};
+    let targetText = norm;
+    // Amount change: "to 700" / "make it 700" / "make the last one 450".
+    const amt = norm.match(/\b(?:to|make it|make the [a-z ]+?one)\s+(\d[\d,]*(?:\.\d+)?)/);
+    if (amt && amt.index !== undefined) {
+        changes.amount = parseFloat(amt[1].replace(/,/g, ""));
+        targetText = norm.slice(0, amt.index);
+    }
+    // Category change: "as groceries" / "into food" / "recategorize as health".
+    const cat = norm.match(/\b(?:as|into|category to)\s+([a-z ]+)$/);
+    if (cat && cat.index !== undefined) {
+        const c = categoryOf(cat[1]);
+        if (c) {
+            changes.category = c;
+            targetText = norm.slice(0, cat.index);
+        }
+    }
+    return { target: parseTarget(targetText), changes };
+}
+function parseCommand(transcript) {
+    const raw = transcript ?? "";
+    const text = (0, normalize_1.normalize)(raw);
+    if (!text)
+        return { kind: "unknown", transcript: raw, confidence: 0 };
+    // 1. delete
+    if (DELETE_RE.test(text)) {
+        return { kind: "delete", target: parseTarget(text), confidence: 0.9 };
+    }
+    // 2. set_limit (a limit/target keyword + an amount)
+    if (LIMIT_RE.test(text)) {
+        const amount = (0, amount_1.extractAmount)(text).amount;
+        if (amount !== null) {
+            const which = /\bmonth|\bmonthly|\bmas|\btarget\b/.test(text) ? "monthly" : "daily";
+            return { kind: "set_limit", which, amount, confidence: 0.9 };
+        }
+    }
+    // 3. navigate
+    if (NAV_INSIGHTS_RE.test(text)) {
+        return { kind: "navigate", to: "insights", confidence: 0.9 };
+    }
+    if (NAV_HOME_RE.test(text) && /\b(go|open|show|navigate|take me)\b/.test(text)) {
+        return { kind: "navigate", to: "home", confidence: 0.85 };
+    }
+    // 4. update
+    if (EDIT_RE.test(text)) {
+        const { target, changes } = parseUpdate(text);
+        if (changes.amount !== undefined || changes.category !== undefined) {
+            return { kind: "update", target, changes, confidence: 0.85 };
+        }
+    }
+    // 5. query
+    if (BALANCE_RE.test(text)) {
+        return {
+            kind: "query",
+            query: { metric: "balance", category: null, period: "all" },
+            confidence: 0.85,
+        };
+    }
+    if (TOTAL_RE.test(text)) {
+        const query = {
+            metric: "total_spend",
+            category: categoryOf(text),
+            period: detectPeriod(text),
+        };
+        return { kind: "query", query, confidence: 0.85 };
+    }
+    // 6. create (the original capture path) — only if there's an amount.
+    const draft = (0, parser_1.parseTranscript)(raw);
+    if (draft.amount !== null) {
+        return { kind: "create", draft, confidence: draft.confidence };
+    }
+    // 7. unknown
+    return { kind: "unknown", transcript: raw, confidence: 0 };
+}

--- a/voice/packages/shared/dist/command/resolve.d.ts
+++ b/voice/packages/shared/dist/command/resolve.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Reference resolution and query execution over stored transactions.
+ *
+ * Both run client-side against the already-loaded expense list — no extra API
+ * calls. `resolveTarget` returns ranked candidates (best first) so the UI can
+ * show the match for confirmation before any destructive action.
+ */
+import type { Category } from "../types";
+import type { ExpenseRecord, Period, QuerySpec, TargetQuery } from "./types";
+/**
+ * Rank stored records against a spoken reference. Filters by any specified
+ * facet (category / counterparty / amount), then orders by recency. `first`
+ * flips to oldest-first. Returns [] when nothing matches.
+ */
+export declare function resolveTarget(q: TargetQuery, records: ExpenseRecord[]): ExpenseRecord[];
+export interface QueryResult {
+    metric: QuerySpec["metric"];
+    /** For total_spend: the summed amount. For by_category: omitted. */
+    total: number;
+    count: number;
+    category: Category | null;
+    period: Period;
+    /** For by_category breakdowns. */
+    breakdown?: Array<{
+        category: Category;
+        total: number;
+    }>;
+    /** A ready-to-speak/display sentence. `balance` is filled in by the caller. */
+    text: string;
+}
+/**
+ * Execute a spending query. `balance` is not computed here (it needs the user's
+ * opening balance) — the UI handles that case and only uses this for spend.
+ */
+export declare function runQuery(spec: QuerySpec, records: ExpenseRecord[], now?: Date): QueryResult;

--- a/voice/packages/shared/dist/command/resolve.js
+++ b/voice/packages/shared/dist/command/resolve.js
@@ -1,0 +1,104 @@
+"use strict";
+/**
+ * Reference resolution and query execution over stored transactions.
+ *
+ * Both run client-side against the already-loaded expense list — no extra API
+ * calls. `resolveTarget` returns ranked candidates (best first) so the UI can
+ * show the match for confirmation before any destructive action.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolveTarget = resolveTarget;
+exports.runQuery = runQuery;
+const types_1 = require("../types");
+function startOfPeriod(period, now) {
+    if (period === "all")
+        return null;
+    const d = new Date(now);
+    d.setHours(0, 0, 0, 0);
+    if (period === "today")
+        return d;
+    if (period === "week") {
+        d.setDate(d.getDate() - d.getDay()); // week starts Sunday
+        return d;
+    }
+    // month
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+}
+function inPeriod(iso, period, now) {
+    const start = startOfPeriod(period, now);
+    if (!start)
+        return true;
+    return new Date(iso).getTime() >= start.getTime();
+}
+/**
+ * Rank stored records against a spoken reference. Filters by any specified
+ * facet (category / counterparty / amount), then orders by recency. `first`
+ * flips to oldest-first. Returns [] when nothing matches.
+ */
+function resolveTarget(q, records) {
+    let c = records.slice();
+    if (q.category)
+        c = c.filter((r) => r.category === q.category);
+    if (q.counterparty) {
+        const needle = q.counterparty.toLowerCase();
+        c = c.filter((r) => r.title.toLowerCase().includes(needle) ||
+            r.details.toLowerCase().includes(needle));
+    }
+    if (q.amount !== null) {
+        c = c.filter((r) => Math.abs(r.amount - q.amount) < 0.01);
+    }
+    c.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    if (q.ordinal === "first")
+        c.reverse();
+    return c;
+}
+const taka = (n) => `৳${n.toLocaleString("en-IN", { maximumFractionDigits: 2 })}`;
+const periodPhrase = {
+    today: "today",
+    week: "this week",
+    month: "this month",
+    all: "in total",
+};
+/**
+ * Execute a spending query. `balance` is not computed here (it needs the user's
+ * opening balance) — the UI handles that case and only uses this for spend.
+ */
+function runQuery(spec, records, now = new Date()) {
+    const spend = records.filter((r) => r.type === "remove" && inPeriod(r.createdAt, spec.period, now));
+    if (spec.metric === "by_category") {
+        const map = new Map();
+        for (const r of spend) {
+            const key = r.category ?? "other";
+            map.set(key, (map.get(key) ?? 0) + r.amount);
+        }
+        const breakdown = [...map.entries()]
+            .map(([category, total]) => ({ category: category, total }))
+            .sort((a, b) => b.total - a.total);
+        const total = breakdown.reduce((s, b) => s + b.total, 0);
+        return {
+            metric: "by_category",
+            total,
+            count: spend.length,
+            category: null,
+            period: spec.period,
+            breakdown,
+            text: `You spent ${taka(total)} ${periodPhrase[spec.period]}.`,
+        };
+    }
+    // total_spend (optionally filtered by category)
+    const filtered = spec.category
+        ? spend.filter((r) => r.category === spec.category)
+        : spend;
+    const total = filtered.reduce((s, r) => s + r.amount, 0);
+    const where = spec.category ? ` on ${types_1.CATEGORY_LABELS[spec.category]}` : "";
+    return {
+        metric: "total_spend",
+        total,
+        count: filtered.length,
+        category: spec.category,
+        period: spec.period,
+        text: filtered.length === 0
+            ? `No spending${where} ${periodPhrase[spec.period]}.`
+            : `You spent ${taka(total)}${where} ${periodPhrase[spec.period]} across ${filtered.length} ${filtered.length === 1 ? "transaction" : "transactions"}.`,
+    };
+}

--- a/voice/packages/shared/dist/command/types.d.ts
+++ b/voice/packages/shared/dist/command/types.d.ts
@@ -1,0 +1,79 @@
+/**
+ * Voice command intents. Sits in front of the capture parser: a transcript is
+ * first classified into one of these, then the app routes it to an action.
+ *
+ * This is a deterministic grammar — it recognizes patterns, not arbitrary
+ * phrasing. The supported shapes are documented per-intent in parse.ts and
+ * surfaced to the user as example commands in the UI.
+ */
+import type { Category, ParsedTransaction } from "../types";
+export type Period = "today" | "week" | "month" | "all";
+/** How to find an existing transaction the user referred to by voice. */
+export interface TargetQuery {
+    /** "my last lunch" → "last"; "the oldest" → "first"; otherwise null. */
+    ordinal: "last" | "first" | null;
+    category: Category | null;
+    counterparty: string | null;
+    /** "the 600 one" → 600. */
+    amount: number | null;
+}
+/** Field changes for an edit command. Only set fields are changed. */
+export interface TransactionChanges {
+    amount?: number;
+    category?: Category;
+    direction?: "expense" | "income";
+    counterparty?: string;
+    note?: string;
+}
+export interface QuerySpec {
+    metric: "total_spend" | "balance" | "by_category";
+    category: Category | null;
+    period: Period;
+}
+/** Discriminated union of everything the user can ask for by voice. */
+export type Command = {
+    kind: "create";
+    draft: ParsedTransaction;
+    confidence: number;
+} | {
+    kind: "delete";
+    target: TargetQuery;
+    confidence: number;
+} | {
+    kind: "update";
+    target: TargetQuery;
+    changes: TransactionChanges;
+    confidence: number;
+} | {
+    kind: "query";
+    query: QuerySpec;
+    confidence: number;
+} | {
+    kind: "set_limit";
+    which: "daily" | "monthly";
+    amount: number;
+    confidence: number;
+} | {
+    kind: "navigate";
+    to: "home" | "insights";
+    confidence: number;
+} | {
+    kind: "unknown";
+    transcript: string;
+    confidence: 0;
+};
+/**
+ * App-agnostic view of a stored transaction, used for reference resolution and
+ * queries. The web app maps its `expenses` rows onto this shape.
+ */
+export interface ExpenseRecord {
+    id: number | string;
+    title: string;
+    /** Absolute amount (always positive); `type` carries the sign. */
+    amount: number;
+    type: "add" | "remove";
+    category: string | null;
+    details: string;
+    /** ISO 8601 timestamp. */
+    createdAt: string;
+}

--- a/voice/packages/shared/dist/command/types.js
+++ b/voice/packages/shared/dist/command/types.js
@@ -1,0 +1,10 @@
+"use strict";
+/**
+ * Voice command intents. Sits in front of the capture parser: a transcript is
+ * first classified into one of these, then the app routes it to an action.
+ *
+ * This is a deterministic grammar — it recognizes patterns, not arbitrary
+ * phrasing. The supported shapes are documented per-intent in parse.ts and
+ * surfaced to the user as example commands in the UI.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/voice/packages/shared/dist/index.d.ts
+++ b/voice/packages/shared/dist/index.d.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./parser";
+export * from "./command";

--- a/voice/packages/shared/dist/parser/category.js
+++ b/voice/packages/shared/dist/parser/category.js
@@ -13,7 +13,7 @@ const normalize_1 = require("./normalize");
 /** category → trigger words/phrases (all lowercase, matched as substrings/words). */
 const KEYWORDS = {
     food: [
-        "lunch", "dinner", "breakfast", "khabar", "khawa", "khelam", "restaurant",
+        "food", "lunch", "dinner", "breakfast", "khabar", "khawa", "khelam", "restaurant",
         "hotel", "cafe", "coffee", "cha", "tea", "snacks", "biryani", "fast food",
         "dupure khabar", "rater khabar", "nasta", "খাবার", "খাওয়া",
     ],

--- a/voice/packages/shared/package.json
+++ b/voice/packages/shared/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "node --import tsx --test src/parser.test.ts"
+    "test": "node --import tsx --test src/parser.test.ts src/command.test.ts"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/voice/packages/shared/src/command.test.ts
+++ b/voice/packages/shared/src/command.test.ts
@@ -1,0 +1,133 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseCommand } from "./command/parse";
+import { resolveTarget, runQuery } from "./command/resolve";
+
+// --- intent classification ---
+
+test("create still routes through (has amount, no command verb)", () => {
+  const c = parseCommand("just spent 600 on lunch with Rafi");
+  assert.equal(c.kind, "create");
+  if (c.kind === "create") assert.equal(c.draft.amount, 600);
+});
+
+test("delete: 'delete my last lunch'", () => {
+  const c = parseCommand("delete my last lunch");
+  assert.equal(c.kind, "delete");
+  if (c.kind === "delete") {
+    assert.equal(c.target.ordinal, "last");
+    assert.equal(c.target.category, "food");
+  }
+});
+
+test("delete by amount: 'remove the 600 taka one'", () => {
+  const c = parseCommand("remove the 600 taka one");
+  assert.equal(c.kind, "delete");
+  if (c.kind === "delete") assert.equal(c.target.amount, 600);
+});
+
+test("update amount: 'change that 600 to 700'", () => {
+  const c = parseCommand("change that 600 to 700");
+  assert.equal(c.kind, "update");
+  if (c.kind === "update") {
+    assert.equal(c.changes.amount, 700);
+    assert.equal(c.target.amount, 600);
+  }
+});
+
+test("update category: 'recategorize my last lunch as groceries'", () => {
+  const c = parseCommand("recategorize my last lunch as groceries");
+  assert.equal(c.kind, "update");
+  if (c.kind === "update") {
+    assert.equal(c.changes.category, "groceries");
+    assert.equal(c.target.ordinal, "last");
+    assert.equal(c.target.category, "food");
+  }
+});
+
+test("set_limit daily: 'set my daily limit to 1000'", () => {
+  const c = parseCommand("set my daily limit to 1000");
+  assert.equal(c.kind, "set_limit");
+  if (c.kind === "set_limit") {
+    assert.equal(c.which, "daily");
+    assert.equal(c.amount, 1000);
+  }
+});
+
+test("set_limit monthly: 'monthly target 30000'", () => {
+  const c = parseCommand("monthly target 30000");
+  assert.equal(c.kind, "set_limit");
+  if (c.kind === "set_limit") {
+    assert.equal(c.which, "monthly");
+    assert.equal(c.amount, 30000);
+  }
+});
+
+test("query total: 'how much did I spend on food this week'", () => {
+  const c = parseCommand("how much did I spend on food this week");
+  assert.equal(c.kind, "query");
+  if (c.kind === "query") {
+    assert.equal(c.query.metric, "total_spend");
+    assert.equal(c.query.category, "food");
+    assert.equal(c.query.period, "week");
+  }
+});
+
+test("query balance: \"what's my balance\"", () => {
+  const c = parseCommand("what's my balance");
+  assert.equal(c.kind, "query");
+  if (c.kind === "query") assert.equal(c.query.metric, "balance");
+});
+
+test("navigate: 'show insights'", () => {
+  const c = parseCommand("show insights");
+  assert.equal(c.kind, "navigate");
+  if (c.kind === "navigate") assert.equal(c.to, "insights");
+});
+
+test("unknown: gibberish with no amount or verb", () => {
+  assert.equal(parseCommand("hello there").kind, "unknown");
+});
+
+// --- resolution + query over records ---
+
+const records = [
+  { id: 1, title: "Food · Rafi", amount: 600, type: "remove", category: "food", details: "lunch with rafi", createdAt: "2026-06-29T12:00:00Z" },
+  { id: 2, title: "Transport", amount: 150, type: "remove", category: "transport", details: "cng", createdAt: "2026-06-29T09:00:00Z" },
+  { id: 3, title: "Food", amount: 250, type: "remove", category: "food", details: "snacks", createdAt: "2026-06-28T18:00:00Z" },
+  { id: 4, title: "Salary", amount: 30000, type: "add", category: "salary", details: "june", createdAt: "2026-06-25T10:00:00Z" },
+] as const;
+
+test("resolveTarget: last food → most recent food row", () => {
+  const c = parseCommand("delete my last food");
+  assert.equal(c.kind, "delete");
+  if (c.kind !== "delete") return;
+  const hits = resolveTarget(c.target, records as any);
+  assert.equal(hits[0].id, 1); // 600 lunch, newest food
+  assert.equal(hits.length, 2);
+});
+
+test("resolveTarget: by amount 250 → the snacks row", () => {
+  const hits = resolveTarget(
+    { ordinal: null, category: null, counterparty: null, amount: 250 },
+    records as any
+  );
+  assert.equal(hits[0].id, 3);
+});
+
+test("runQuery: total food spend (all) = 850", () => {
+  const r = runQuery(
+    { metric: "total_spend", category: "food", period: "all" },
+    records as any
+  );
+  assert.equal(r.total, 850);
+  assert.equal(r.count, 2);
+});
+
+test("runQuery: income excluded from spend totals", () => {
+  const r = runQuery(
+    { metric: "total_spend", category: null, period: "all" },
+    records as any
+  );
+  assert.equal(r.total, 1000); // 600 + 150 + 250, NOT the 30000 salary
+});

--- a/voice/packages/shared/src/command/index.ts
+++ b/voice/packages/shared/src/command/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export { parseCommand } from "./parse";
+export { resolveTarget, runQuery } from "./resolve";
+export type { QueryResult } from "./resolve";

--- a/voice/packages/shared/src/command/parse.ts
+++ b/voice/packages/shared/src/command/parse.ts
@@ -1,0 +1,154 @@
+/**
+ * parseCommand: transcript → Command (intent + entities).
+ *
+ * Detection runs in a fixed precedence so overlapping keywords resolve
+ * predictably:
+ *   1. delete   — "delete/remove ..."
+ *   2. set_limit — mentions a limit/target + an amount ("set daily limit to 1000")
+ *   3. navigate — names a destination ("show insights", "go home")
+ *   4. update   — "change/edit/recategorize ..."
+ *   5. query    — "how much ...", "what's my balance"
+ *   6. create   — falls through here if there's an amount (the capture path)
+ *   7. unknown  — nothing recognized
+ *
+ * Supported edit/delete phrasings (deterministic, not free-form):
+ *   delete:  "delete my last lunch", "remove the 600 taka one", "delete the last one"
+ *   update:  "change that 600 to 700", "make the last one 450",
+ *            "recategorize my last lunch as groceries"
+ *   query:   "how much did I spend on food this week", "what's my balance"
+ *   limit:   "set my daily limit to 1000", "monthly target 30000"
+ *   nav:     "show insights", "go to dashboard"
+ */
+
+import type { Category } from "../types";
+import { normalize } from "../parser/normalize";
+import { extractAmount } from "../parser/amount";
+import { extractCategory } from "../parser/category";
+import { extractCounterparty } from "../parser/counterparty";
+import { parseTranscript } from "../parser";
+import type { Command, Period, QuerySpec, TargetQuery, TransactionChanges } from "./types";
+
+const DELETE_RE = /\b(delete|remove|cancel|muche|baad|mucho)\b/;
+const EDIT_RE = /\b(change|update|edit|recategorize|rename|make)\b/;
+const LIMIT_RE = /\b(limit|target)\b/;
+const BALANCE_RE = /\b(balance|baki)\b/;
+const TOTAL_RE = /\b(how much|how many|koto|total|ktotal)\b/;
+const NAV_INSIGHTS_RE = /\b(insight|insights|report|reports|analytics|chart|charts)\b/;
+const NAV_HOME_RE = /\b(home|dashboard|main)\b/;
+
+function detectPeriod(text: string): Period {
+  if (/\b(today|aj|ajke)\b/.test(text)) return "today";
+  if (/\b(this week|week|saptah|saptaho)\b/.test(text)) return "week";
+  if (/\b(this month|month|mas|mash)\b/.test(text)) return "month";
+  return "month"; // most useful default for a spending question
+}
+
+/** Pull a category out of a fragment, or null if none is confident. */
+function categoryOf(text: string): Category | null {
+  const r = extractCategory(text);
+  return r.category !== "other" && r.confidence > 0 ? r.category : null;
+}
+
+function parseTarget(text: string): TargetQuery {
+  const norm = normalize(text);
+  const ordinal: TargetQuery["ordinal"] = /\b(last|recent|latest|sesh|previous)\b/.test(
+    norm
+  )
+    ? "last"
+    : /\b(first|oldest|earliest)\b/.test(norm)
+      ? "first"
+      : null;
+  return {
+    ordinal,
+    category: categoryOf(norm),
+    counterparty: extractCounterparty(text).counterparty,
+    amount: extractAmount(norm).amount,
+  };
+}
+
+function parseUpdate(text: string): { target: TargetQuery; changes: TransactionChanges } {
+  const norm = normalize(text);
+  const changes: TransactionChanges = {};
+  let targetText = norm;
+
+  // Amount change: "to 700" / "make it 700" / "make the last one 450".
+  const amt = norm.match(/\b(?:to|make it|make the [a-z ]+?one)\s+(\d[\d,]*(?:\.\d+)?)/);
+  if (amt && amt.index !== undefined) {
+    changes.amount = parseFloat(amt[1].replace(/,/g, ""));
+    targetText = norm.slice(0, amt.index);
+  }
+
+  // Category change: "as groceries" / "into food" / "recategorize as health".
+  const cat = norm.match(/\b(?:as|into|category to)\s+([a-z ]+)$/);
+  if (cat && cat.index !== undefined) {
+    const c = categoryOf(cat[1]);
+    if (c) {
+      changes.category = c;
+      targetText = norm.slice(0, cat.index);
+    }
+  }
+
+  return { target: parseTarget(targetText), changes };
+}
+
+export function parseCommand(transcript: string): Command {
+  const raw = transcript ?? "";
+  const text = normalize(raw);
+  if (!text) return { kind: "unknown", transcript: raw, confidence: 0 };
+
+  // 1. delete
+  if (DELETE_RE.test(text)) {
+    return { kind: "delete", target: parseTarget(text), confidence: 0.9 };
+  }
+
+  // 2. set_limit (a limit/target keyword + an amount)
+  if (LIMIT_RE.test(text)) {
+    const amount = extractAmount(text).amount;
+    if (amount !== null) {
+      const which = /\bmonth|\bmonthly|\bmas|\btarget\b/.test(text) ? "monthly" : "daily";
+      return { kind: "set_limit", which, amount, confidence: 0.9 };
+    }
+  }
+
+  // 3. navigate
+  if (NAV_INSIGHTS_RE.test(text)) {
+    return { kind: "navigate", to: "insights", confidence: 0.9 };
+  }
+  if (NAV_HOME_RE.test(text) && /\b(go|open|show|navigate|take me)\b/.test(text)) {
+    return { kind: "navigate", to: "home", confidence: 0.85 };
+  }
+
+  // 4. update
+  if (EDIT_RE.test(text)) {
+    const { target, changes } = parseUpdate(text);
+    if (changes.amount !== undefined || changes.category !== undefined) {
+      return { kind: "update", target, changes, confidence: 0.85 };
+    }
+  }
+
+  // 5. query
+  if (BALANCE_RE.test(text)) {
+    return {
+      kind: "query",
+      query: { metric: "balance", category: null, period: "all" },
+      confidence: 0.85,
+    };
+  }
+  if (TOTAL_RE.test(text)) {
+    const query: QuerySpec = {
+      metric: "total_spend",
+      category: categoryOf(text),
+      period: detectPeriod(text),
+    };
+    return { kind: "query", query, confidence: 0.85 };
+  }
+
+  // 6. create (the original capture path) — only if there's an amount.
+  const draft = parseTranscript(raw);
+  if (draft.amount !== null) {
+    return { kind: "create", draft, confidence: draft.confidence };
+  }
+
+  // 7. unknown
+  return { kind: "unknown", transcript: raw, confidence: 0 };
+}

--- a/voice/packages/shared/src/command/resolve.ts
+++ b/voice/packages/shared/src/command/resolve.ts
@@ -1,0 +1,134 @@
+/**
+ * Reference resolution and query execution over stored transactions.
+ *
+ * Both run client-side against the already-loaded expense list — no extra API
+ * calls. `resolveTarget` returns ranked candidates (best first) so the UI can
+ * show the match for confirmation before any destructive action.
+ */
+
+import type { Category } from "../types";
+import { CATEGORY_LABELS } from "../types";
+import type { ExpenseRecord, Period, QuerySpec, TargetQuery } from "./types";
+
+function startOfPeriod(period: Period, now: Date): Date | null {
+  if (period === "all") return null;
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  if (period === "today") return d;
+  if (period === "week") {
+    d.setDate(d.getDate() - d.getDay()); // week starts Sunday
+    return d;
+  }
+  // month
+  return new Date(now.getFullYear(), now.getMonth(), 1);
+}
+
+function inPeriod(iso: string, period: Period, now: Date): boolean {
+  const start = startOfPeriod(period, now);
+  if (!start) return true;
+  return new Date(iso).getTime() >= start.getTime();
+}
+
+/**
+ * Rank stored records against a spoken reference. Filters by any specified
+ * facet (category / counterparty / amount), then orders by recency. `first`
+ * flips to oldest-first. Returns [] when nothing matches.
+ */
+export function resolveTarget(q: TargetQuery, records: ExpenseRecord[]): ExpenseRecord[] {
+  let c = records.slice();
+
+  if (q.category) c = c.filter((r) => r.category === q.category);
+  if (q.counterparty) {
+    const needle = q.counterparty.toLowerCase();
+    c = c.filter(
+      (r) =>
+        r.title.toLowerCase().includes(needle) ||
+        r.details.toLowerCase().includes(needle)
+    );
+  }
+  if (q.amount !== null) {
+    c = c.filter((r) => Math.abs(r.amount - (q.amount as number)) < 0.01);
+  }
+
+  c.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  if (q.ordinal === "first") c.reverse();
+  return c;
+}
+
+export interface QueryResult {
+  metric: QuerySpec["metric"];
+  /** For total_spend: the summed amount. For by_category: omitted. */
+  total: number;
+  count: number;
+  category: Category | null;
+  period: Period;
+  /** For by_category breakdowns. */
+  breakdown?: Array<{ category: Category; total: number }>;
+  /** A ready-to-speak/display sentence. `balance` is filled in by the caller. */
+  text: string;
+}
+
+const taka = (n: number) =>
+  `৳${n.toLocaleString("en-IN", { maximumFractionDigits: 2 })}`;
+
+const periodPhrase: Record<Period, string> = {
+  today: "today",
+  week: "this week",
+  month: "this month",
+  all: "in total",
+};
+
+/**
+ * Execute a spending query. `balance` is not computed here (it needs the user's
+ * opening balance) — the UI handles that case and only uses this for spend.
+ */
+export function runQuery(
+  spec: QuerySpec,
+  records: ExpenseRecord[],
+  now: Date = new Date()
+): QueryResult {
+  const spend = records.filter(
+    (r) => r.type === "remove" && inPeriod(r.createdAt, spec.period, now)
+  );
+
+  if (spec.metric === "by_category") {
+    const map = new Map<string, number>();
+    for (const r of spend) {
+      const key = r.category ?? "other";
+      map.set(key, (map.get(key) ?? 0) + r.amount);
+    }
+    const breakdown = [...map.entries()]
+      .map(([category, total]) => ({ category: category as Category, total }))
+      .sort((a, b) => b.total - a.total);
+    const total = breakdown.reduce((s, b) => s + b.total, 0);
+    return {
+      metric: "by_category",
+      total,
+      count: spend.length,
+      category: null,
+      period: spec.period,
+      breakdown,
+      text: `You spent ${taka(total)} ${periodPhrase[spec.period]}.`,
+    };
+  }
+
+  // total_spend (optionally filtered by category)
+  const filtered = spec.category
+    ? spend.filter((r) => r.category === spec.category)
+    : spend;
+  const total = filtered.reduce((s, r) => s + r.amount, 0);
+  const where = spec.category ? ` on ${CATEGORY_LABELS[spec.category]}` : "";
+  return {
+    metric: "total_spend",
+    total,
+    count: filtered.length,
+    category: spec.category,
+    period: spec.period,
+    text:
+      filtered.length === 0
+        ? `No spending${where} ${periodPhrase[spec.period]}.`
+        : `You spent ${taka(total)}${where} ${periodPhrase[spec.period]} across ${filtered.length} ${
+            filtered.length === 1 ? "transaction" : "transactions"
+          }.`,
+  };
+}

--- a/voice/packages/shared/src/command/types.ts
+++ b/voice/packages/shared/src/command/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Voice command intents. Sits in front of the capture parser: a transcript is
+ * first classified into one of these, then the app routes it to an action.
+ *
+ * This is a deterministic grammar — it recognizes patterns, not arbitrary
+ * phrasing. The supported shapes are documented per-intent in parse.ts and
+ * surfaced to the user as example commands in the UI.
+ */
+
+import type { Category, ParsedTransaction } from "../types";
+
+export type Period = "today" | "week" | "month" | "all";
+
+/** How to find an existing transaction the user referred to by voice. */
+export interface TargetQuery {
+  /** "my last lunch" → "last"; "the oldest" → "first"; otherwise null. */
+  ordinal: "last" | "first" | null;
+  category: Category | null;
+  counterparty: string | null;
+  /** "the 600 one" → 600. */
+  amount: number | null;
+}
+
+/** Field changes for an edit command. Only set fields are changed. */
+export interface TransactionChanges {
+  amount?: number;
+  category?: Category;
+  direction?: "expense" | "income";
+  counterparty?: string;
+  note?: string;
+}
+
+export interface QuerySpec {
+  metric: "total_spend" | "balance" | "by_category";
+  category: Category | null;
+  period: Period;
+}
+
+/** Discriminated union of everything the user can ask for by voice. */
+export type Command =
+  | { kind: "create"; draft: ParsedTransaction; confidence: number }
+  | { kind: "delete"; target: TargetQuery; confidence: number }
+  | {
+      kind: "update";
+      target: TargetQuery;
+      changes: TransactionChanges;
+      confidence: number;
+    }
+  | { kind: "query"; query: QuerySpec; confidence: number }
+  | { kind: "set_limit"; which: "daily" | "monthly"; amount: number; confidence: number }
+  | { kind: "navigate"; to: "home" | "insights"; confidence: number }
+  | { kind: "unknown"; transcript: string; confidence: 0 };
+
+/**
+ * App-agnostic view of a stored transaction, used for reference resolution and
+ * queries. The web app maps its `expenses` rows onto this shape.
+ */
+export interface ExpenseRecord {
+  id: number | string;
+  title: string;
+  /** Absolute amount (always positive); `type` carries the sign. */
+  amount: number;
+  type: "add" | "remove";
+  category: string | null;
+  details: string;
+  /** ISO 8601 timestamp. */
+  createdAt: string;
+}

--- a/voice/packages/shared/src/index.ts
+++ b/voice/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./parser";
+export * from "./command";

--- a/voice/packages/shared/src/parser/category.ts
+++ b/voice/packages/shared/src/parser/category.ts
@@ -13,7 +13,7 @@ import { normalize } from "./normalize";
 /** category → trigger words/phrases (all lowercase, matched as substrings/words). */
 const KEYWORDS: Record<Exclude<Category, "other">, string[]> = {
   food: [
-    "lunch", "dinner", "breakfast", "khabar", "khawa", "khelam", "restaurant",
+    "food", "lunch", "dinner", "breakfast", "khabar", "khawa", "khelam", "restaurant",
     "hotel", "cafe", "coffee", "cha", "tea", "snacks", "biryani", "fast food",
     "dupure khabar", "rater khabar", "nasta", "খাবার", "খাওয়া",
   ],


### PR DESCRIPTION
Voice command layer (deterministic, offline — no LLM/API cost):
- voice/packages/shared/src/command: parseCommand classifies a transcript into create / delete / update / query / set_limit / navigate; resolveTarget + runQuery handle reference resolution and spending questions client-side.
- components/voiceCapture.js: routes intents — editable draft for create, confirmation panel for delete/edit, inline + spoken answers for queries, confirm for set-limit, navigation. Destructive actions are confirmation-gated.
- pages/api/updateexpense: new endpoint so transactions can be edited (previously only insert/delete existed).

Auth:
- Google OAuth added alongside the existing dummy credentials login (kept as-is). Registered only when GOOGLE_CLIENT_ID/SECRET are set; sign-in gated by a verified email + optional ALLOWED_GOOGLE_EMAILS allowlist.
- "Continue with Google" button on the sign-in page (shown when configured).