### PR TITLE
Scope all data per user via user_id

### DIFF
--- a/migrations/003_reset_user_id.sql
+++ b/migrations/003_reset_user_id.sql
@@ -1,0 +1,46 @@
+-- ⚠️ DESTRUCTIVE fresh start. Drops and rebuilds the three data tables keyed by
+-- user_id (instead of email). Run this INSTEAD of migrations 001 and 002 — it
+-- supersedes them. Existing transactions/balance/insights are wiped (approved:
+-- data is disposable here). The `users` table and the dummy account are kept.
+--
+-- After this, the app provisions a users row per login (incl. Google) on sign-in
+-- and scopes all data by users.user_id.
+
+BEGIN;
+
+-- OAuth users have no password — make it optional.
+ALTER TABLE users ALTER COLUMN password DROP NOT NULL;
+
+DROP TABLE IF EXISTS expenses CASCADE;
+DROP TABLE IF EXISTS balance CASCADE;
+DROP TABLE IF EXISTS insights CASCADE;
+
+CREATE TABLE expenses (
+    expense_id     SERIAL PRIMARY KEY,
+    expense_title  VARCHAR(255) NOT NULL,
+    expense_details TEXT,
+    created_date   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_date   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    status         BOOLEAN DEFAULT TRUE,
+    expense        NUMERIC(10, 2) NOT NULL,
+    expense_type   VARCHAR(10) CHECK (expense_type IN ('add', 'remove')),
+    category       VARCHAR(40),
+    user_id        INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+CREATE INDEX idx_expenses_user_id ON expenses (user_id);
+CREATE INDEX idx_expenses_category ON expenses (category);
+
+CREATE TABLE balance (
+    id              SERIAL PRIMARY KEY,
+    current_balance NUMERIC(15, 2) DEFAULT 0,
+    user_id         INTEGER UNIQUE NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE insights (
+    id                     SERIAL PRIMARY KEY,
+    daily_limit            NUMERIC(10, 2) DEFAULT 0,
+    monthly_expense_target NUMERIC(10, 2) DEFAULT 0,
+    user_id                INTEGER UNIQUE NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+COMMIT;

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,6 +1,7 @@
 import NextAuth from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import GoogleProvider from "next-auth/providers/google";
+import conn from "../../../lib/db";
 
 export const authOptions = {
   // Support both casing variations for the secret
@@ -91,11 +92,39 @@ export const authOptions = {
       return true;
     },
     async jwt({ token, user }) {
-      return { ...token, ...user };
+      // On sign-in, resolve a stable numeric user_id (find-or-create by email).
+      // This is what unifies the dummy login and Google onto one identity and
+      // gives every account a real `users` row to scope data against.
+      if (user) {
+        const email = (user.email || token.email || "").toLowerCase();
+        if (email) {
+          try {
+            await conn.query(
+              "INSERT INTO users (email) VALUES ($1) ON CONFLICT (email) DO NOTHING",
+              [email]
+            );
+            const r = await conn.query(
+              "SELECT user_id FROM users WHERE email = $1",
+              [email]
+            );
+            token.uid = r.rows[0]?.user_id ?? token.uid;
+          } catch (e) {
+            console.error("User provisioning failed:", e);
+          }
+          token.email = email;
+        }
+        if (user.name) token.name = user.name;
+      }
+      return token;
     },
-    async session({ session, token, user }) {
-      // Send properties to the client, like an access_token from a provider.
-      session.user = token;
+    async session({ session, token }) {
+      // Expose the numeric user id (uid) that the data API routes scope by.
+      session.user = {
+        ...(session.user || {}),
+        uid: token.uid ?? null,
+        email: token.email ?? session.user?.email ?? null,
+        name: token.name ?? session.user?.name ?? null,
+      };
       return session;
     },
   },

--- a/pages/api/deleteexpense/index.js
+++ b/pages/api/deleteexpense/index.js
@@ -4,17 +4,18 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query = "DELETE FROM expenses where expense_id = $1";
-      const values = [req.body.id];
-      const result = await conn.query(query, values);
-      res.send(result);
-    } catch (error) {}
-  } else {
-    // Not Signed in
-    res.status(401);
+  const uid = session?.user?.uid;
+  if (!uid) {
+    res.status(401).end();
+    return;
   }
-  res.end();
+  try {
+    // Scope by user_id so one user can never delete another's row.
+    const query = "DELETE FROM expenses WHERE expense_id = $1 AND user_id = $2";
+    const result = await conn.query(query, [req.body.id, uid]);
+    res.status(200).json(result);
+  } catch (error) {
+    console.error("Database error in deleteexpense:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 };

--- a/pages/api/getDailyLimit/index.js
+++ b/pages/api/getDailyLimit/index.js
@@ -4,16 +4,24 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query = "SELECT daily_limit from insights";
-      const result = await conn.query(query);
-      res.send(result);
-    } catch (error) {}
-  } else {
-    // Not Signed in
-    res.status(401);
+  const uid = session?.user?.uid;
+  if (!uid) {
+    res.status(401).end();
+    return;
   }
-  res.end();
+  try {
+    // Ensure this user has an insights row, then read it.
+    await conn.query(
+      "INSERT INTO insights (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING",
+      [uid]
+    );
+    const result = await conn.query(
+      "SELECT daily_limit from insights where user_id = $1",
+      [uid]
+    );
+    res.status(200).json({ rows: result.rows });
+  } catch (error) {
+    console.error("Database error in getDailyLimit:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 };

--- a/pages/api/getMonthlyExpenseTarget/index.js
+++ b/pages/api/getMonthlyExpenseTarget/index.js
@@ -4,16 +4,23 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query = "SELECT monthly_expense_target from insights";
-      const result = await conn.query(query);
-      res.send(result);
-    } catch (error) {}
-  } else {
-    // Not Signed in
-    res.status(401);
+  const uid = session?.user?.uid;
+  if (!uid) {
+    res.status(401).end();
+    return;
   }
-  res.end();
+  try {
+    await conn.query(
+      "INSERT INTO insights (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING",
+      [uid]
+    );
+    const result = await conn.query(
+      "SELECT monthly_expense_target from insights where user_id = $1",
+      [uid]
+    );
+    res.status(200).json({ rows: result.rows });
+  } catch (error) {
+    console.error("Database error in getMonthlyExpenseTarget:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 };

--- a/pages/api/getbalance/index.js
+++ b/pages/api/getbalance/index.js
@@ -4,18 +4,22 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query = "SELECT current_balance from balance";
-      const result = await conn.query(query);
-      res.status(200).json(result);
-    } catch (error) {
-      console.error("Database error in getbalance:", error);
-      res.status(500).json({ error: "Internal Server Error" });
-    }
-  } else {
-    // Not Signed in
+  const uid = session?.user?.uid;
+  if (!uid) {
     res.status(401).end();
+    return;
+  }
+  try {
+    const result = await conn.query(
+      "SELECT current_balance from balance where user_id = $1",
+      [uid]
+    );
+    // New users have no balance row yet → report 0 (same shape the client reads).
+    res
+      .status(200)
+      .json({ rows: result.rows.length ? result.rows : [{ current_balance: 0 }] });
+  } catch (error) {
+    console.error("Database error in getbalance:", error);
+    res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/pages/api/getexpenselist/index.js
+++ b/pages/api/getexpenselist/index.js
@@ -4,19 +4,18 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query =
-        "SELECT expense_id, expense_title, expense_details, created_date, updated_date, status, expense, expense_type, category from expenses order by created_date desc";
-      const result = await conn.query(query);
-      res.status(200).json(result);
-    } catch (error) {
-      console.error("Database error in getexpenselist:", error);
-      res.status(500).json({ error: "Internal Server Error" });
-    }
-  } else {
-    // Not Signed in
+  const uid = session?.user?.uid;
+  if (!uid) {
     res.status(401).end();
+    return;
+  }
+  try {
+    const query =
+      "SELECT expense_id, expense_title, expense_details, created_date, updated_date, status, expense, expense_type, category from expenses where user_id = $1 order by created_date desc";
+    const result = await conn.query(query, [uid]);
+    res.status(200).json(result);
+  } catch (error) {
+    console.error("Database error in getexpenselist:", error);
+    res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/pages/api/insertexpense/index.js
+++ b/pages/api/insertexpense/index.js
@@ -4,30 +4,30 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query =
-        "INSERT INTO expenses(expense_title, expense_details, created_date, updated_date, status, expense, expense_type, category) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)";
-      const date = new Date();
-      const values = [
-        req.body.title,
-        req.body.details,
-        date,
-        date,
-        true,
-        req.body.expense,
-        req.body.type,
-        req.body.category ?? null,
-      ];
-      const result = await conn.query(query, values);
-      res.status(200).json(result);
-    } catch (error) {
-      console.error("Database error in insertexpense:", error);
-      res.status(500).json({ error: "Internal Server Error" });
-    }
-  } else {
-    // Not Signed in
+  const uid = session?.user?.uid;
+  if (!uid) {
     res.status(401).end();
+    return;
+  }
+  try {
+    const query =
+      "INSERT INTO expenses(expense_title, expense_details, created_date, updated_date, status, expense, expense_type, category, user_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)";
+    const date = new Date();
+    const values = [
+      req.body.title,
+      req.body.details,
+      date,
+      date,
+      true,
+      req.body.expense,
+      req.body.type,
+      req.body.category ?? null,
+      uid,
+    ];
+    const result = await conn.query(query, values);
+    res.status(200).json(result);
+  } catch (error) {
+    console.error("Database error in insertexpense:", error);
+    res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/pages/api/updateDailyLimit/index.js
+++ b/pages/api/updateDailyLimit/index.js
@@ -4,17 +4,19 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query = "UPDATE insights SET daily_limit = $1";
-      const values = [req.body.dailyLimit];
-      const result = await conn.query(query, values);
-      res.send(result);
-    } catch (error) {}
-  } else {
-    // Not Signed in
-    res.status(401);
+  const uid = session?.user?.uid;
+  if (!uid) {
+    res.status(401).end();
+    return;
   }
-  res.end();
+  try {
+    const query = `
+      INSERT INTO insights (user_id, daily_limit) VALUES ($1, $2)
+      ON CONFLICT (user_id) DO UPDATE SET daily_limit = EXCLUDED.daily_limit`;
+    const result = await conn.query(query, [uid, req.body.dailyLimit]);
+    res.status(200).json(result);
+  } catch (error) {
+    console.error("Database error in updateDailyLimit:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 };

--- a/pages/api/updateMonthlyExpenseTarget/index.js
+++ b/pages/api/updateMonthlyExpenseTarget/index.js
@@ -4,17 +4,19 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query = "UPDATE insights SET monthly_expense_target = $1";
-      const values = [req.body.monthlyExpenseTarget];
-      const result = await conn.query(query, values);
-      res.send(result);
-    } catch (error) {}
-  } else {
-    // Not Signed in
-    res.status(401);
+  const uid = session?.user?.uid;
+  if (!uid) {
+    res.status(401).end();
+    return;
   }
-  res.end();
+  try {
+    const query = `
+      INSERT INTO insights (user_id, monthly_expense_target) VALUES ($1, $2)
+      ON CONFLICT (user_id) DO UPDATE SET monthly_expense_target = EXCLUDED.monthly_expense_target`;
+    const result = await conn.query(query, [uid, req.body.monthlyExpenseTarget]);
+    res.status(200).json(result);
+  } catch (error) {
+    console.error("Database error in updateMonthlyExpenseTarget:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 };

--- a/pages/api/updatebalance/index.js
+++ b/pages/api/updatebalance/index.js
@@ -4,17 +4,20 @@ import { authOptions } from "../auth/[...nextauth]";
 
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (session) {
-    // Signed in
-    try {
-      const query = "UPDATE balance SET current_balance = $1";
-      const values = [req.body.balance];
-      const result = await conn.query(query, values);
-      res.send(result);
-    } catch (error) {}
-  } else {
-    // Not Signed in
-    res.status(401);
+  const uid = session?.user?.uid;
+  if (!uid) {
+    res.status(401).end();
+    return;
   }
-  res.end();
+  try {
+    // Upsert this user's single balance row.
+    const query = `
+      INSERT INTO balance (user_id, current_balance) VALUES ($1, $2)
+      ON CONFLICT (user_id) DO UPDATE SET current_balance = EXCLUDED.current_balance`;
+    const result = await conn.query(query, [uid, req.body.balance]);
+    res.status(200).json(result);
+  } catch (error) {
+    console.error("Database error in updatebalance:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 };

--- a/pages/api/updateexpense/index.js
+++ b/pages/api/updateexpense/index.js
@@ -6,7 +6,8 @@ import { authOptions } from "../auth/[...nextauth]";
 // (COALESCE keeps the current value for anything sent as null/undefined).
 export default async (req, res) => {
   const session = await getServerSession(req, res, authOptions);
-  if (!session) {
+  const uid = session?.user?.uid;
+  if (!uid) {
     res.status(401).end();
     return;
   }
@@ -16,6 +17,7 @@ export default async (req, res) => {
       res.status(400).json({ error: "id is required" });
       return;
     }
+    // The user_id guard ensures a user can only edit their own rows.
     const query = `
       UPDATE expenses SET
         expense_title  = COALESCE($2, expense_title),
@@ -24,7 +26,7 @@ export default async (req, res) => {
         expense_type   = COALESCE($5, expense_type),
         category       = COALESCE($6, category),
         updated_date   = $7
-      WHERE expense_id = $1`;
+      WHERE expense_id = $1 AND user_id = $8`;
     const values = [
       id,
       title ?? null,
@@ -33,6 +35,7 @@ export default async (req, res) => {
       type ?? null,
       category ?? null,
       new Date(),
+      uid,
     ];
     const result = await conn.query(query, values);
     res.status(200).json(result);

--- a/setup.sql
+++ b/setup.sql
@@ -1,14 +1,17 @@
 -- setup.sql
 -- Run this script in your PostgreSQL database to create the necessary tables and initial data.
+-- All transaction data is scoped per user via user_id (see migrations/003 for the
+-- migration path on an existing DB).
 
--- 1. Create Users table
+-- 1. Create Users table. password is nullable: Google (OAuth) users have none;
+--    they're provisioned automatically on first sign-in.
 CREATE TABLE IF NOT EXISTS users (
     user_id SERIAL PRIMARY KEY,
     email VARCHAR(255) UNIQUE NOT NULL,
-    password TEXT NOT NULL
+    password TEXT
 );
 
--- 2. Create Expenses table
+-- 2. Create Expenses table (owned by a user)
 CREATE TABLE IF NOT EXISTS expenses (
     expense_id SERIAL PRIMARY KEY,
     expense_title VARCHAR(255) NOT NULL,
@@ -18,30 +21,27 @@ CREATE TABLE IF NOT EXISTS expenses (
     status BOOLEAN DEFAULT TRUE,
     expense NUMERIC(10, 2) NOT NULL,
     expense_type VARCHAR(10) CHECK (expense_type IN ('add', 'remove')),
-    category VARCHAR(40)
+    category VARCHAR(40),
+    user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
 );
+CREATE INDEX IF NOT EXISTS idx_expenses_user_id ON expenses (user_id);
+CREATE INDEX IF NOT EXISTS idx_expenses_category ON expenses (category);
 
--- 3. Create Balance table
+-- 3. Create Balance table (one row per user)
 CREATE TABLE IF NOT EXISTS balance (
     id SERIAL PRIMARY KEY,
-    current_balance NUMERIC(15, 2) DEFAULT 0
+    current_balance NUMERIC(15, 2) DEFAULT 0,
+    user_id INTEGER UNIQUE NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
 );
 
--- 4. Create Insights table
+-- 4. Create Insights table (one row per user)
 CREATE TABLE IF NOT EXISTS insights (
     id SERIAL PRIMARY KEY,
     daily_limit NUMERIC(10, 2) DEFAULT 0,
-    monthly_expense_target NUMERIC(10, 2) DEFAULT 0
+    monthly_expense_target NUMERIC(10, 2) DEFAULT 0,
+    user_id INTEGER UNIQUE NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
 );
 
--- 5. Insert Initial Data (Optional - Update with your own)
--- NOTE: Update the password with your desired password.
--- The login API uses bcrypt to securely verify passwords.
+-- 5. Seed the dummy demo account (password: password123, bcrypt-hashed).
+--    Per-user balance/insights rows are created automatically on first use.
 INSERT INTO users (email, password) VALUES ('user@example.com', '$2b$10$udhtJgowWKUcqT59TfahGufZaqD2ZHl0Rn2IOWkzJQxqfLoFw1TRC') ON CONFLICT DO NOTHING;
-
--- Initialize balance and insights if they are empty
-INSERT INTO balance (current_balance) SELECT 0 WHERE NOT EXISTS (SELECT 1 FROM balance);
-INSERT INTO insights (daily_limit, monthly_expense_target) SELECT 1000, 30000 WHERE NOT EXISTS (SELECT 1 FROM insights);
-
--- 6. Sample indicator for expenses (Optional)
--- INSERT INTO expenses (expense_title, expense_details, expense, expense_type) VALUES ('Sample Income', 'Initial balance boost', 500.00, 'add');


### PR DESCRIPTION
Move from shared-global data to per-user isolation keyed by users.user_id.

- Auth: sign-in now provisions a users row (find-or-create by email) for both the dummy credentials login and Google, exposing a numeric user_id as session.user.uid. users.password is now nullable (OAuth users have none).
- All 10 data API routes scope by user_id; delete/edit guard on it so a user can't touch another's rows. balance/insights are one-row-per-user with upsert-on-write and auto-create-on-read.
- migrations/003_reset_user_id.sql: destructive rebuild of expenses/balance/ insights keyed by user_id (supersedes the earlier category/user_email migrations). setup.sql updated to the final schema for fresh installs.