### PR TITLE
Improve Bangla coverage and spelled-out number parsing

### DIFF
--- a/voice/packages/shared/dist/command/parse.js
+++ b/voice/packages/shared/dist/command/parse.js
@@ -88,8 +88,9 @@ function parseCommand(transcript) {
     const text = (0, normalize_1.normalize)(raw);
     if (!text)
         return { kind: "unknown", transcript: raw, confidence: 0 };
-    // 1. delete
-    if (DELETE_RE.test(text)) {
+    // 1. delete (regex for romanized/English; includes() for Bangla script,
+    //    since \b word boundaries don't fire around Bangla characters)
+    if (DELETE_RE.test(text) || ["মুছে", "বাদ দাও", "ডিলিট"].some((w) => text.includes(w))) {
         return { kind: "delete", target: parseTarget(text), confidence: 0.9 };
     }
     // 2. set_limit (a limit/target keyword + an amount)
@@ -115,14 +116,14 @@ function parseCommand(transcript) {
         }
     }
     // 5. query
-    if (BALANCE_RE.test(text)) {
+    if (BALANCE_RE.test(text) || ["ব্যালেন্স", "ব্যালান্স"].some((w) => text.includes(w))) {
         return {
             kind: "query",
             query: { metric: "balance", category: null, period: "all" },
             confidence: 0.85,
         };
     }
-    if (TOTAL_RE.test(text)) {
+    if (TOTAL_RE.test(text) || text.includes("কত খরচ") || text.includes("কত টাকা")) {
         const query = {
             metric: "total_spend",
             category: categoryOf(text),

--- a/voice/packages/shared/dist/parser/amount.js
+++ b/voice/packages/shared/dist/parser/amount.js
@@ -10,6 +10,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.extractAmount = extractAmount;
 const normalize_1 = require("./normalize");
+const words_1 = require("./words");
 /** Scale words → multiplier. Ordered longest-first isn't needed; regex handles it. */
 const SCALE = {
     k: 1000,
@@ -45,8 +46,13 @@ function extractAmount(rawText) {
             moneyAdjacent: isMoneyAdjacent(text, m.index ?? 0),
         });
     }
-    if (matches.length === 0)
+    if (matches.length === 0) {
+        // No digits — try a spelled-out amount ("panch sho taka", "five hundred").
+        const w = (0, words_1.wordsToNumber)(text);
+        if (w)
+            return { amount: w.value, confidence: w.hadScale ? 0.8 : 0.55 };
         return { amount: null, confidence: 0 };
+    }
     // Prefer a number sitting next to a money word ("600 taka"); it's the most
     // reliable signal. Otherwise fall back to the first number we saw.
     const moneyAdjacent = matches.filter((m) => m.moneyAdjacent);

--- a/voice/packages/shared/dist/parser/category.js
+++ b/voice/packages/shared/dist/parser/category.js
@@ -15,53 +15,64 @@ const KEYWORDS = {
     food: [
         "food", "lunch", "dinner", "breakfast", "khabar", "khawa", "khelam", "restaurant",
         "hotel", "cafe", "coffee", "cha", "tea", "snacks", "biryani", "fast food",
-        "dupure khabar", "rater khabar", "nasta", "খাবার", "খাওয়া",
+        "dupure khabar", "rater khabar", "nasta", "খাবার", "খাওয়া", "চা",
+        "রেস্টুরেন্ট", "নাস্তা",
     ],
     groceries: [
         "grocery", "groceries", "bazar", "bazaar", "vegetables", "sobji", "shobji",
-        "rice", "chal", "dal", "mudi", "kacha bazar", "বাজার",
+        "rice", "chal", "dal", "mudi", "kacha bazar", "বাজার", "সবজি", "চাল",
+        "ডাল", "মুদি",
     ],
     transport: [
         "uber", "pathao", "cng", "rickshaw", "riksha", "bus", "train", "bhara",
         "vara", "fuel", "petrol", "gas", "taxi", "ride", "transport", "রিকশা",
+        "বাস", "সিএনজি", "গাড়ি", "ভাড়া দিলাম",
     ],
-    rent: ["rent", "bari vara", "basa vara", "house rent", "flat", "vara baki", "ভাড়া"],
+    rent: ["rent", "bari vara", "basa vara", "flat vara", "house rent", "flat", "vara baki", "ভাড়া", "বাসা ভাড়া"],
     bills: [
         "bill", "electricity", "current bill", "wasa", "water bill", "gas bill",
-        "internet", "wifi", "dish", "utility", "বিল",
+        "internet", "wifi", "dish", "utility", "বিল", "বিদ্যুৎ", "পানির বিল",
+        "ইন্টারনেট", "গ্যাস বিল",
     ],
     mobile_recharge: [
         "recharge", "flexiload", "flexi", "topup", "top up", "minute", "mb",
         "data pack", "gp", "robi", "banglalink", "airtel", "teletalk", "রিচার্জ",
     ],
     shopping: [
-        "shopping", "shirt", "pant", "jutা", "juta", "shoe", "dress", "panjabi",
+        "shopping", "shirt", "pant", "juta", "shoe", "dress", "panjabi",
         "saree", "shari", "clothes", "kapor", "gift", "daraz", "online order",
+        "জামা", "কাপড়", "জুতা", "শাড়ি", "পাঞ্জাবি",
     ],
     health: [
         "doctor", "medicine", "ousud", "oushod", "pharmacy", "hospital", "clinic",
-        "test", "checkup", "ডাক্তার", "ঔষধ",
+        "test", "checkup", "ডাক্তার", "ঔষধ", "ওষুধ", "হাসপাতাল", "ফার্মেসি",
     ],
     education: [
         "tuition", "coaching", "books", "boi", "exam fee", "admission", "course",
-        "school", "college", "university", "fees", "বেতন",
+        "school", "college", "university", "fees", "টিউশন", "বই", "স্কুল",
+        "কলেজ", "কোর্স",
     ],
     entertainment: [
         "movie", "cinema", "ticket", "concert", "game", "netflix", "subscription",
-        "ghora", "ghurte", "outing", "park",
+        "ghora", "ghurte", "outing", "park", "সিনেমা", "টিকিট", "ঘুরতে",
     ],
     transfer: [
         "send money", "cash out", "cashout", "transfer", "pathalam", "dilam taka",
-        "bkash korlam", "nagad korlam", "tk pathai", "send korlam",
+        "bkash korlam", "nagad korlam", "tk pathai", "send korlam", "পাঠালাম",
+        "ক্যাশ আউট",
     ],
-    salary: ["salary", "beton", "income", "pelam", "peyechi", "received", "bonus", "বেতন পেলাম"],
+    salary: [
+        "salary", "beton", "income", "pelam", "peyechi", "received", "bonus",
+        "বেতন পেলাম", "বেতন", "আয়", "বোনাস",
+    ],
 };
 function extractCategory(rawText) {
     const text = (0, normalize_1.normalize)(rawText);
     // Whole-word token set so short keywords like "cha" (tea) don't match inside
-    // longer words like "recharge". Splits on anything that isn't a letter/digit,
-    // which keeps Bangla-script words (\p{L}) intact as single tokens.
-    const wordSet = new Set(text.split(/[^\p{L}\p{N}]+/u).filter(Boolean));
+    // longer words like "recharge". We split on anything that isn't a letter,
+    // digit, or combining mark — \p{M} matters because Bangla vowel signs (matras,
+    // e.g. া in টাকা) are marks, and excluding them would shatter Bangla words.
+    const wordSet = new Set(text.split(/[^\p{L}\p{N}\p{M}]+/u).filter(Boolean));
     let best = { category: "other", score: 0 };
     for (const [cat, words] of Object.entries(KEYWORDS)) {
         let score = 0;

--- a/voice/packages/shared/dist/parser/index.d.ts
+++ b/voice/packages/shared/dist/parser/index.d.ts
@@ -13,4 +13,5 @@ export { extractCategory } from "./category";
 export { extractCounterparty } from "./counterparty";
 export { extractDirection } from "./direction";
 export { extractPaymentMethod } from "./payment";
+export { wordsToNumber } from "./words";
 export declare function parseTranscript(rawTranscript: string): ParsedTransaction;

--- a/voice/packages/shared/dist/parser/index.js
+++ b/voice/packages/shared/dist/parser/index.js
@@ -22,7 +22,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.extractPaymentMethod = exports.extractDirection = exports.extractCounterparty = exports.extractCategory = exports.extractAmount = void 0;
+exports.wordsToNumber = exports.extractPaymentMethod = exports.extractDirection = exports.extractCounterparty = exports.extractCategory = exports.extractAmount = void 0;
 exports.parseTranscript = parseTranscript;
 const amount_1 = require("./amount");
 const category_1 = require("./category");
@@ -40,6 +40,8 @@ var direction_2 = require("./direction");
 Object.defineProperty(exports, "extractDirection", { enumerable: true, get: function () { return direction_2.extractDirection; } });
 var payment_2 = require("./payment");
 Object.defineProperty(exports, "extractPaymentMethod", { enumerable: true, get: function () { return payment_2.extractPaymentMethod; } });
+var words_1 = require("./words");
+Object.defineProperty(exports, "wordsToNumber", { enumerable: true, get: function () { return words_1.wordsToNumber; } });
 function parseTranscript(rawTranscript) {
     const text = rawTranscript ?? "";
     const amount = (0, amount_1.extractAmount)(text);

--- a/voice/packages/shared/dist/parser/words.d.ts
+++ b/voice/packages/shared/dist/parser/words.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Spelled-out number parsing for amounts, English + romanized Bangla.
+ *
+ * Complements the digit parser in amount.ts (which handles "600", "5k",
+ * "5 hazar"). This handles fully-spelled amounts people actually say:
+ *   "five hundred"        → 500
+ *   "panch sho taka"      → 500
+ *   "dosh hajar"          → 10000
+ *   "ek lakh"             → 100000
+ *   "two thousand five hundred" → 2500
+ *
+ * Romanized Bangla numbers are irregular, so we deliberately include only the
+ * unambiguous, commonly-spoken words (1–10, a few tens, and the scales). Bangla
+ * *script* digits (৫০০) are already converted upstream by normalize().
+ */
+interface ComposeResult {
+    value: number;
+    /** Whether a scale word (hundred/thousand/…) was part of the number. */
+    hadScale: boolean;
+}
+/**
+ * Parse the largest spelled-out number in the text. Splits on non-number words
+ * so "five hundred on lunch with two friends" yields 500 (not 502). Returns
+ * null when there are no number words.
+ */
+export declare function wordsToNumber(text: string): ComposeResult | null;
+export {};

--- a/voice/packages/shared/dist/parser/words.js
+++ b/voice/packages/shared/dist/parser/words.js
@@ -1,0 +1,96 @@
+"use strict";
+/**
+ * Spelled-out number parsing for amounts, English + romanized Bangla.
+ *
+ * Complements the digit parser in amount.ts (which handles "600", "5k",
+ * "5 hazar"). This handles fully-spelled amounts people actually say:
+ *   "five hundred"        → 500
+ *   "panch sho taka"      → 500
+ *   "dosh hajar"          → 10000
+ *   "ek lakh"             → 100000
+ *   "two thousand five hundred" → 2500
+ *
+ * Romanized Bangla numbers are irregular, so we deliberately include only the
+ * unambiguous, commonly-spoken words (1–10, a few tens, and the scales). Bangla
+ * *script* digits (৫০০) are already converted upstream by normalize().
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.wordsToNumber = wordsToNumber;
+const normalize_1 = require("./normalize");
+/** Small number words → value. English + safe romanized Bangla. */
+const UNITS = {
+    // english
+    zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7,
+    eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12, thirteen: 13,
+    fourteen: 14, fifteen: 15, sixteen: 16, seventeen: 17, eighteen: 18,
+    nineteen: 19, twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60,
+    seventy: 70, eighty: 80, ninety: 90,
+    // romanized bangla (1–10)
+    ek: 1, dui: 2, tin: 3, char: 4, panch: 5, choy: 6, chhoy: 6, sat: 7,
+    shat: 7, ath: 8, at: 8, noy: 9, noi: 9, dosh: 10,
+    // romanized bangla teens / tens (unambiguous ones only)
+    egaro: 11, baro: 12, tero: 13, choddo: 14, ponero: 15, sholo: 16,
+    bish: 20, kuri: 20, tirish: 30, chollish: 40, ponchash: 50,
+};
+/** Scale/multiplier words. */
+const SCALES = {
+    hundred: 100, sho: 100, shoto: 100,
+    thousand: 1000, hajar: 1000, hazar: 1000,
+    lakh: 100000, lac: 100000,
+    million: 1000000,
+};
+/** Evaluate one contiguous run of number words using place-value composition. */
+function composeRun(tokens) {
+    let total = 0;
+    let current = 0;
+    let hadScale = false;
+    let used = false;
+    for (const t of tokens) {
+        if (t in UNITS) {
+            current += UNITS[t];
+            used = true;
+        }
+        else {
+            const s = SCALES[t];
+            hadScale = true;
+            used = true;
+            if (s === 100)
+                current = (current || 1) * 100;
+            else {
+                total += (current || 1) * s;
+                current = 0;
+            }
+        }
+    }
+    if (!used)
+        return null;
+    const value = total + current;
+    return value > 0 ? { value, hadScale } : null;
+}
+/**
+ * Parse the largest spelled-out number in the text. Splits on non-number words
+ * so "five hundred on lunch with two friends" yields 500 (not 502). Returns
+ * null when there are no number words.
+ */
+function wordsToNumber(text) {
+    const toks = (0, normalize_1.normalize)(text).split(/[^a-z]+/).filter(Boolean);
+    const runs = [];
+    let cur = [];
+    for (const t of toks) {
+        if (t in UNITS || t in SCALES)
+            cur.push(t);
+        else if (cur.length) {
+            runs.push(cur);
+            cur = [];
+        }
+    }
+    if (cur.length)
+        runs.push(cur);
+    let best = null;
+    for (const r of runs) {
+        const v = composeRun(r);
+        if (v && (!best || v.value > best.value))
+            best = v;
+    }
+    return best;
+}

--- a/voice/packages/shared/src/command.test.ts
+++ b/voice/packages/shared/src/command.test.ts
@@ -89,6 +89,24 @@ test("unknown: gibberish with no amount or verb", () => {
   assert.equal(parseCommand("hello there").kind, "unknown");
 });
 
+test("Bangla delete: 'মুছে ফেলো my last lunch'", () => {
+  const c = parseCommand("মুছে ফেলো my last lunch");
+  assert.equal(c.kind, "delete");
+  if (c.kind === "delete") assert.equal(c.target.ordinal, "last");
+});
+
+test("Bangla balance query: 'ব্যালেন্স koto'", () => {
+  const c = parseCommand("ব্যালেন্স koto");
+  assert.equal(c.kind, "query");
+  if (c.kind === "query") assert.equal(c.query.metric, "balance");
+});
+
+test("word-number create: 'panch sho taka lunch' routes to create", () => {
+  const c = parseCommand("panch sho taka lunch e khorch");
+  assert.equal(c.kind, "create");
+  if (c.kind === "create") assert.equal(c.draft.amount, 500);
+});
+
 // --- resolution + query over records ---
 
 const records = [

--- a/voice/packages/shared/src/command/parse.ts
+++ b/voice/packages/shared/src/command/parse.ts
@@ -96,8 +96,9 @@ export function parseCommand(transcript: string): Command {
   const text = normalize(raw);
   if (!text) return { kind: "unknown", transcript: raw, confidence: 0 };
 
-  // 1. delete
-  if (DELETE_RE.test(text)) {
+  // 1. delete (regex for romanized/English; includes() for Bangla script,
+  //    since \b word boundaries don't fire around Bangla characters)
+  if (DELETE_RE.test(text) || ["মুছে", "বাদ দাও", "ডিলিট"].some((w) => text.includes(w))) {
     return { kind: "delete", target: parseTarget(text), confidence: 0.9 };
   }
 
@@ -127,14 +128,14 @@ export function parseCommand(transcript: string): Command {
   }
 
   // 5. query
-  if (BALANCE_RE.test(text)) {
+  if (BALANCE_RE.test(text) || ["ব্যালেন্স", "ব্যালান্স"].some((w) => text.includes(w))) {
     return {
       kind: "query",
       query: { metric: "balance", category: null, period: "all" },
       confidence: 0.85,
     };
   }
-  if (TOTAL_RE.test(text)) {
+  if (TOTAL_RE.test(text) || text.includes("কত খরচ") || text.includes("কত টাকা")) {
     const query: QuerySpec = {
       metric: "total_spend",
       category: categoryOf(text),

--- a/voice/packages/shared/src/parser.test.ts
+++ b/voice/packages/shared/src/parser.test.ts
@@ -57,3 +57,48 @@ test("empty input is safe", () => {
   assert.equal(r.amount, null);
   assert.equal(r.category, "other");
 });
+
+// --- spelled-out numbers (English + romanized Bangla) ---
+
+test("word-number: 'panch sho taka' = 500", () => {
+  assert.equal(parseTranscript("panch sho taka khoroch holo").amount, 500);
+});
+
+test("word-number: 'dosh hajar' rent = 10000", () => {
+  const r = parseTranscript("dosh hajar taka flat vara dilam");
+  assert.equal(r.amount, 10000);
+  assert.equal(r.category, "rent");
+});
+
+test("word-number: 'ek lakh' = 100000", () => {
+  assert.equal(parseTranscript("ek lakh taka").amount, 100000);
+});
+
+test("word-number: 'five hundred on lunch' = 500, food", () => {
+  const r = parseTranscript("five hundred on lunch");
+  assert.equal(r.amount, 500);
+  assert.equal(r.category, "food");
+});
+
+test("word-number: 'two thousand five hundred' = 2500", () => {
+  assert.equal(parseTranscript("two thousand five hundred taka").amount, 2500);
+});
+
+test("word-number doesn't grab unrelated trailing numbers", () => {
+  // "five hundred ... two" must be 500, not 502
+  assert.equal(parseTranscript("five hundred on lunch with two friends").amount, 500);
+});
+
+// --- Bangla script input ---
+
+test("Bangla digits + Bangla category: '৫০০ টাকা বাজার করলাম'", () => {
+  const r = parseTranscript("৫০০ টাকা বাজার করলাম");
+  assert.equal(r.amount, 500);
+  assert.equal(r.category, "groceries");
+});
+
+test("Bangla category health: 'ওষুধ কিনলাম ২০০ টাকা'", () => {
+  const r = parseTranscript("ওষুধ কিনলাম ২০০ টাকা");
+  assert.equal(r.amount, 200);
+  assert.equal(r.category, "health");
+});

--- a/voice/packages/shared/src/parser/amount.ts
+++ b/voice/packages/shared/src/parser/amount.ts
@@ -8,6 +8,7 @@
  */
 
 import { normalize } from "./normalize";
+import { wordsToNumber } from "./words";
 
 interface AmountMatch {
   value: number;
@@ -60,7 +61,12 @@ export function extractAmount(rawText: string): AmountResult {
     });
   }
 
-  if (matches.length === 0) return { amount: null, confidence: 0 };
+  if (matches.length === 0) {
+    // No digits — try a spelled-out amount ("panch sho taka", "five hundred").
+    const w = wordsToNumber(text);
+    if (w) return { amount: w.value, confidence: w.hadScale ? 0.8 : 0.55 };
+    return { amount: null, confidence: 0 };
+  }
 
   // Prefer a number sitting next to a money word ("600 taka"); it's the most
   // reliable signal. Otherwise fall back to the first number we saw.

--- a/voice/packages/shared/src/parser/category.ts
+++ b/voice/packages/shared/src/parser/category.ts
@@ -15,46 +15,56 @@ const KEYWORDS: Record<Exclude<Category, "other">, string[]> = {
   food: [
     "food", "lunch", "dinner", "breakfast", "khabar", "khawa", "khelam", "restaurant",
     "hotel", "cafe", "coffee", "cha", "tea", "snacks", "biryani", "fast food",
-    "dupure khabar", "rater khabar", "nasta", "খাবার", "খাওয়া",
+    "dupure khabar", "rater khabar", "nasta", "খাবার", "খাওয়া", "চা",
+    "রেস্টুরেন্ট", "নাস্তা",
   ],
   groceries: [
     "grocery", "groceries", "bazar", "bazaar", "vegetables", "sobji", "shobji",
-    "rice", "chal", "dal", "mudi", "kacha bazar", "বাজার",
+    "rice", "chal", "dal", "mudi", "kacha bazar", "বাজার", "সবজি", "চাল",
+    "ডাল", "মুদি",
   ],
   transport: [
     "uber", "pathao", "cng", "rickshaw", "riksha", "bus", "train", "bhara",
     "vara", "fuel", "petrol", "gas", "taxi", "ride", "transport", "রিকশা",
+    "বাস", "সিএনজি", "গাড়ি", "ভাড়া দিলাম",
   ],
-  rent: ["rent", "bari vara", "basa vara", "house rent", "flat", "vara baki", "ভাড়া"],
+  rent: ["rent", "bari vara", "basa vara", "flat vara", "house rent", "flat", "vara baki", "ভাড়া", "বাসা ভাড়া"],
   bills: [
     "bill", "electricity", "current bill", "wasa", "water bill", "gas bill",
-    "internet", "wifi", "dish", "utility", "বিল",
+    "internet", "wifi", "dish", "utility", "বিল", "বিদ্যুৎ", "পানির বিল",
+    "ইন্টারনেট", "গ্যাস বিল",
   ],
   mobile_recharge: [
     "recharge", "flexiload", "flexi", "topup", "top up", "minute", "mb",
     "data pack", "gp", "robi", "banglalink", "airtel", "teletalk", "রিচার্জ",
   ],
   shopping: [
-    "shopping", "shirt", "pant", "jutা", "juta", "shoe", "dress", "panjabi",
+    "shopping", "shirt", "pant", "juta", "shoe", "dress", "panjabi",
     "saree", "shari", "clothes", "kapor", "gift", "daraz", "online order",
+    "জামা", "কাপড়", "জুতা", "শাড়ি", "পাঞ্জাবি",
   ],
   health: [
     "doctor", "medicine", "ousud", "oushod", "pharmacy", "hospital", "clinic",
-    "test", "checkup", "ডাক্তার", "ঔষধ",
+    "test", "checkup", "ডাক্তার", "ঔষধ", "ওষুধ", "হাসপাতাল", "ফার্মেসি",
   ],
   education: [
     "tuition", "coaching", "books", "boi", "exam fee", "admission", "course",
-    "school", "college", "university", "fees", "বেতন",
+    "school", "college", "university", "fees", "টিউশন", "বই", "স্কুল",
+    "কলেজ", "কোর্স",
   ],
   entertainment: [
     "movie", "cinema", "ticket", "concert", "game", "netflix", "subscription",
-    "ghora", "ghurte", "outing", "park",
+    "ghora", "ghurte", "outing", "park", "সিনেমা", "টিকিট", "ঘুরতে",
   ],
   transfer: [
     "send money", "cash out", "cashout", "transfer", "pathalam", "dilam taka",
-    "bkash korlam", "nagad korlam", "tk pathai", "send korlam",
+    "bkash korlam", "nagad korlam", "tk pathai", "send korlam", "পাঠালাম",
+    "ক্যাশ আউট",
   ],
-  salary: ["salary", "beton", "income", "pelam", "peyechi", "received", "bonus", "বেতন পেলাম"],
+  salary: [
+    "salary", "beton", "income", "pelam", "peyechi", "received", "bonus",
+    "বেতন পেলাম", "বেতন", "আয়", "বোনাস",
+  ],
 };
 
 export interface CategoryResult {
@@ -65,9 +75,10 @@ export interface CategoryResult {
 export function extractCategory(rawText: string): CategoryResult {
   const text = normalize(rawText);
   // Whole-word token set so short keywords like "cha" (tea) don't match inside
-  // longer words like "recharge". Splits on anything that isn't a letter/digit,
-  // which keeps Bangla-script words (\p{L}) intact as single tokens.
-  const wordSet = new Set(text.split(/[^\p{L}\p{N}]+/u).filter(Boolean));
+  // longer words like "recharge". We split on anything that isn't a letter,
+  // digit, or combining mark — \p{M} matters because Bangla vowel signs (matras,
+  // e.g. া in টাকা) are marks, and excluding them would shatter Bangla words.
+  const wordSet = new Set(text.split(/[^\p{L}\p{N}\p{M}]+/u).filter(Boolean));
 
   let best: { category: Category; score: number } = { category: "other", score: 0 };
 

--- a/voice/packages/shared/src/parser/index.ts
+++ b/voice/packages/shared/src/parser/index.ts
@@ -20,6 +20,7 @@ export { extractCategory } from "./category";
 export { extractCounterparty } from "./counterparty";
 export { extractDirection } from "./direction";
 export { extractPaymentMethod } from "./payment";
+export { wordsToNumber } from "./words";
 
 export function parseTranscript(rawTranscript: string): ParsedTransaction {
   const text = rawTranscript ?? "";

--- a/voice/packages/shared/src/parser/words.ts
+++ b/voice/packages/shared/src/parser/words.ts
@@ -1,0 +1,101 @@
+/**
+ * Spelled-out number parsing for amounts, English + romanized Bangla.
+ *
+ * Complements the digit parser in amount.ts (which handles "600", "5k",
+ * "5 hazar"). This handles fully-spelled amounts people actually say:
+ *   "five hundred"        → 500
+ *   "panch sho taka"      → 500
+ *   "dosh hajar"          → 10000
+ *   "ek lakh"             → 100000
+ *   "two thousand five hundred" → 2500
+ *
+ * Romanized Bangla numbers are irregular, so we deliberately include only the
+ * unambiguous, commonly-spoken words (1–10, a few tens, and the scales). Bangla
+ * *script* digits (৫০০) are already converted upstream by normalize().
+ */
+
+import { normalize } from "./normalize";
+
+/** Small number words → value. English + safe romanized Bangla. */
+const UNITS: Record<string, number> = {
+  // english
+  zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7,
+  eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12, thirteen: 13,
+  fourteen: 14, fifteen: 15, sixteen: 16, seventeen: 17, eighteen: 18,
+  nineteen: 19, twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60,
+  seventy: 70, eighty: 80, ninety: 90,
+  // romanized bangla (1–10)
+  ek: 1, dui: 2, tin: 3, char: 4, panch: 5, choy: 6, chhoy: 6, sat: 7,
+  shat: 7, ath: 8, at: 8, noy: 9, noi: 9, dosh: 10,
+  // romanized bangla teens / tens (unambiguous ones only)
+  egaro: 11, baro: 12, tero: 13, choddo: 14, ponero: 15, sholo: 16,
+  bish: 20, kuri: 20, tirish: 30, chollish: 40, ponchash: 50,
+};
+
+/** Scale/multiplier words. */
+const SCALES: Record<string, number> = {
+  hundred: 100, sho: 100, shoto: 100,
+  thousand: 1000, hajar: 1000, hazar: 1000,
+  lakh: 100000, lac: 100000,
+  million: 1000000,
+};
+
+interface ComposeResult {
+  value: number;
+  /** Whether a scale word (hundred/thousand/…) was part of the number. */
+  hadScale: boolean;
+}
+
+/** Evaluate one contiguous run of number words using place-value composition. */
+function composeRun(tokens: string[]): ComposeResult | null {
+  let total = 0;
+  let current = 0;
+  let hadScale = false;
+  let used = false;
+
+  for (const t of tokens) {
+    if (t in UNITS) {
+      current += UNITS[t];
+      used = true;
+    } else {
+      const s = SCALES[t];
+      hadScale = true;
+      used = true;
+      if (s === 100) current = (current || 1) * 100;
+      else {
+        total += (current || 1) * s;
+        current = 0;
+      }
+    }
+  }
+
+  if (!used) return null;
+  const value = total + current;
+  return value > 0 ? { value, hadScale } : null;
+}
+
+/**
+ * Parse the largest spelled-out number in the text. Splits on non-number words
+ * so "five hundred on lunch with two friends" yields 500 (not 502). Returns
+ * null when there are no number words.
+ */
+export function wordsToNumber(text: string): ComposeResult | null {
+  const toks = normalize(text).split(/[^a-z]+/).filter(Boolean);
+  const runs: string[][] = [];
+  let cur: string[] = [];
+  for (const t of toks) {
+    if (t in UNITS || t in SCALES) cur.push(t);
+    else if (cur.length) {
+      runs.push(cur);
+      cur = [];
+    }
+  }
+  if (cur.length) runs.push(cur);
+
+  let best: ComposeResult | null = null;
+  for (const r of runs) {
+    const v = composeRun(r);
+    if (v && (!best || v.value > best.value)) best = v;
+  }
+  return best;
+}


### PR DESCRIPTION
- Parse spelled-out amounts (English + romanized Bangla): "panch sho" → 500, "dosh hajar" → 10000, "ek lakh" → 100000, "two thousand five hundred" → 2500. New words.ts, used as a fallback in amount.ts when no digits are present.
- Expand Bangla-script + romanized keywords across all categories; add Bangla command terms (delete / balance / spend queries).
- Fix tokenizer bug: category matching split on [^\p{L}\p{N}], but Bangla vowel signs are \p{M} marks, so Bangla words shattered and never matched. Now keeps combining marks — Bangla-script category detection works.
- Fix "jutা" typo and the বেতন education/salary keyword conflict.
- 34/34 shared unit tests pass (added word-number + Bangla cases).